### PR TITLE
Improve metadata handling in SKYRecord and SKYRecordStorage

### DIFF
--- a/Example/Tests/SKYRecordSerializerTests.m
+++ b/Example/Tests/SKYRecordSerializerTests.m
@@ -174,6 +174,25 @@ SpecBegin(SKYRecordSerializer)
             NSDictionary *dictionary = [serializer dictionaryWithRecord:record];
             expect(dictionary[@"_transient"]).to.beNil();
         });
+
+        it(@"serialize metadata", ^{
+            record.creationDate = [NSDate dateWithTimeIntervalSinceReferenceDate:0];
+            record.creatorUserRecordID = @"creator_id";
+            record.modificationDate = [NSDate dateWithTimeIntervalSinceReferenceDate:1];
+            record.lastModifiedUserRecordID = @"modifier_id";
+            record.ownerUserRecordID = @"owner_id";
+
+            NSDictionary *dictionary = [serializer dictionaryWithRecord:record];
+            expect([SKYDataSerialization
+                       dateFromString:dictionary[SKYRecordSerializationRecordCreatedAtKey]])
+                .to.equal(record.creationDate);
+            expect(dictionary[SKYRecordSerializationRecordCreatorIDKey]).to.equal(@"creator_id");
+            expect([SKYDataSerialization
+                       dateFromString:dictionary[SKYRecordSerializationRecordUpdatedAtKey]])
+                .to.equal(record.modificationDate);
+            expect(dictionary[SKYRecordSerializationRecordUpdaterIDKey]).to.equal(@"modifier_id");
+            expect(dictionary[SKYRecordSerializationRecordOwnerIDKey]).to.equal(@"owner_id");
+        });
     });
 
 SpecEnd

--- a/Example/Tests/SKYRecordStorageBackingStoreTests.m
+++ b/Example/Tests/SKYRecordStorageBackingStoreTests.m
@@ -196,6 +196,11 @@ sharedExamples(@"SKYRecordStorageBackingStore-Records", ^(NSDictionary *data) {
         record = [[SKYRecord alloc] initWithRecordID:recordID data:nil];
         record[@"title"] = @"Hello World";
         record.transient[@"temporary"] = @YES;
+        record.creationDate = [NSDate date];
+        record.creatorUserRecordID = @"creator_user_id";
+        record.modificationDate = [NSDate date];
+        record.lastModifiedUserRecordID = @"modifier_user_id";
+        record.ownerUserRecordID = @"owner_user_id";
 
         localRecord = [[SKYRecord alloc] initWithRecordID:recordID data:nil];
         localRecord[@"title"] = @"Hello World 2";
@@ -214,6 +219,8 @@ sharedExamples(@"SKYRecordStorageBackingStore-Records", ^(NSDictionary *data) {
         SKYRecord *fetchedRecord = [backingStore fetchRecordWithRecordID:record.recordID];
         expect(fetchedRecord[@"title"]).to.equal(record[@"title"]);
         expect(fetchedRecord.transient[@"temporary"]).to.equal(@YES);
+        expect(fetchedRecord.creationDate).toNot.beNil();
+        expect(fetchedRecord.lastModifiedUserRecordID).to.equal(@"modifier_user_id");
 
         // Modify record
         record[@"title"] = @"Bye World";

--- a/Pod/Classes/RecordStorage/SKYRecordStorage.m
+++ b/Pod/Classes/RecordStorage/SKYRecordStorage.m
@@ -181,6 +181,9 @@ NSString *const SKYRecordStorageDeletedRecordIDsKey = @"deletedRecordIDs";
     if ([record creatorUserRecordID] == nil) {
         [record setCreatorUserRecordID:record.lastModifiedUserRecordID];
     }
+    if ([record ownerUserRecordID] == nil) {
+        [record setOwnerUserRecordID:record.lastModifiedUserRecordID];
+    }
 
     [self _setCacheRecord:record recordID:record.recordID];
     [self _appendChange:change record:record completion:handler];

--- a/Pod/Classes/SKYAccessControl.h
+++ b/Pod/Classes/SKYAccessControl.h
@@ -24,7 +24,7 @@
 @class SKYUser;
 @class SKYRole;
 
-@interface SKYAccessControl : NSObject
+@interface SKYAccessControl : NSObject <NSCoding, NSCopying>
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/Pod/Classes/SKYAccessControl.m
+++ b/Pod/Classes/SKYAccessControl.m
@@ -276,4 +276,23 @@
     return [self hasAccessForEntry:[SKYAccessControlEntry writeEntryForPublic]];
 }
 
+#pragma mark - NSCoding
+
+- (void)encodeWithCoder:(NSCoder *)aCoder
+{
+    [aCoder encodeObject:[self.entries array] forKey:@"entries"];
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder
+{
+    return [self initWithEntries:[aDecoder decodeObjectForKey:@"entries"]];
+}
+
+#pragma mark - NSCopying
+
+- (id)copyWithZone:(NSZone *)zone
+{
+    return [[[self class] alloc] initWithEntries:[self.entries array]];
+}
+
 @end

--- a/Pod/Classes/SKYAccessControlEntry.h
+++ b/Pod/Classes/SKYAccessControlEntry.h
@@ -38,7 +38,7 @@ typedef enum : NSUInteger {
 NSString *NSStringFromAccessControlEntryLevel(SKYAccessControlEntryLevel);
 
 // NOTE(limouren): this class is consider an implementation details of SKYAccessControl
-@interface SKYAccessControlEntry : NSObject
+@interface SKYAccessControlEntry : NSObject <NSCoding>
 
 + (instancetype)readEntryForUser:(SKYUser *)user;
 + (instancetype)readEntryForUserID:(NSString *)user;

--- a/Pod/Classes/SKYAccessControlEntry.m
+++ b/Pod/Classes/SKYAccessControlEntry.m
@@ -188,4 +188,38 @@ NSString *NSStringFromAccessControlEntryLevel(SKYAccessControlEntryLevel level)
     return [[self alloc] initWithPublicAccessLevel:SKYAccessControlEntryLevelWrite];
 }
 
+#pragma mark - NSCoding
+
+- (void)encodeWithCoder:(NSCoder *)aCoder
+{
+    [aCoder encodeInteger:self.entryType forKey:@"entryType"];
+    [aCoder encodeInteger:self.accessLevel forKey:@"accessLevel"];
+    [aCoder encodeObject:self.relation forKey:@"relation"];
+    [aCoder encodeObject:self.role forKey:@"role"];
+    [aCoder encodeObject:self.userID forKey:@"userID"];
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder
+{
+    SKYAccessControlEntryType entryType = [aDecoder decodeIntegerForKey:@"entryType"];
+    SKYAccessControlEntryLevel accessLevel = [aDecoder decodeIntegerForKey:@"accessLevel"];
+    switch (entryType) {
+        case SKYAccessControlEntryTypeRelation:
+            return [self initWithAccessLevel:accessLevel
+                                    relation:[aDecoder decodeObjectOfClass:[SKYRelation class]
+                                                                    forKey:@"relation"]];
+        case SKYAccessControlEntryTypeDirect:
+            return [self initWithAccessLevel:accessLevel
+                                      userID:[aDecoder decodeObjectOfClass:[NSString class]
+                                                                    forKey:@"userID"]];
+        case SKYAccessControlEntryTypeRole:
+            return [self
+                initWithAccessLevel:accessLevel
+                               role:[aDecoder decodeObjectOfClass:[SKYRole class] forKey:@"role"]];
+        case SKYAccessControlEntryTypePublic:
+            return [self initWithPublicAccessLevel:accessLevel];
+    }
+    return nil;
+}
+
 @end

--- a/Pod/Classes/SKYRecord.m
+++ b/Pod/Classes/SKYRecord.m
@@ -113,6 +113,12 @@ NSString *const SKYRecordTypeUserRecord = @"_User";
     record->_recordID = [_recordID copyWithZone:zone];
     record->_object = [_object mutableCopyWithZone:zone];
     record->_transient = [_transient mutableCopyWithZone:zone];
+    record->_ownerUserRecordID = [_ownerUserRecordID copyWithZone:zone];
+    record->_creationDate = [_creationDate copyWithZone:zone];
+    record->_creatorUserRecordID = [_creatorUserRecordID copyWithZone:zone];
+    record->_modificationDate = [_modificationDate copyWithZone:zone];
+    record->_lastModifiedUserRecordID = [_lastModifiedUserRecordID copyWithZone:zone];
+    record->_accessControl = [_accessControl copyWithZone:zone];
     return record;
 }
 

--- a/Pod/Classes/SKYRecordSerializer.m
+++ b/Pod/Classes/SKYRecordSerializer.m
@@ -44,6 +44,28 @@
     payload[SKYRecordSerializationRecordIDKey] = record.recordID.canonicalString;
     payload[SKYRecordSerializationRecordTypeKey] = @"record";
 
+    if (record.creationDate) {
+        payload[SKYRecordSerializationRecordCreatedAtKey] =
+            [SKYDataSerialization stringFromDate:record.creationDate];
+    }
+
+    if (record.creatorUserRecordID.length) {
+        payload[SKYRecordSerializationRecordCreatorIDKey] = record.creatorUserRecordID;
+    }
+
+    if (record.modificationDate) {
+        payload[SKYRecordSerializationRecordUpdatedAtKey] =
+            [SKYDataSerialization stringFromDate:record.modificationDate];
+    }
+
+    if (record.lastModifiedUserRecordID.length) {
+        payload[SKYRecordSerializationRecordUpdaterIDKey] = record.lastModifiedUserRecordID;
+    }
+
+    if (record.ownerUserRecordID) {
+        payload[SKYRecordSerializationRecordOwnerIDKey] = record.ownerUserRecordID;
+    }
+
     // NOTE(limouren): this checking is mostly for test cases.
     // It is not expected for a record deserialized from web response to have
     // nil accessControl.

--- a/Pod/Classes/SKYRelation.h
+++ b/Pod/Classes/SKYRelation.h
@@ -25,7 +25,7 @@ typedef enum : NSInteger {
     SKYRelationDirectionMutual
 } SKYRelationDirection;
 
-@interface SKYRelation : NSObject
+@interface SKYRelation : NSObject <NSCoding>
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/Pod/Classes/SKYRelation.m
+++ b/Pod/Classes/SKYRelation.m
@@ -113,4 +113,18 @@
     return [_name hash] ^ _direction;
 }
 
+#pragma mark - NSCoding
+
+- (void)encodeWithCoder:(NSCoder *)aCoder
+{
+    [aCoder encodeObject:self.name forKey:@"name"];
+    [aCoder encodeInteger:self.direction forKey:@"direction"];
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder
+{
+    return [self initWithName:[aDecoder decodeObjectOfClass:[NSString class] forKey:@"name"]
+                    direction:[aDecoder decodeIntegerForKey:@"direction"]];
+}
+
 @end

--- a/Pod/Classes/SKYRole.h
+++ b/Pod/Classes/SKYRole.h
@@ -19,7 +19,7 @@
 
 #import <Foundation/Foundation.h>
 
-@interface SKYRole : NSObject
+@interface SKYRole : NSObject <NSCoding>
 
 @property (strong, nonatomic, readonly) NSString *name;
 

--- a/Pod/Classes/SKYRole.m
+++ b/Pod/Classes/SKYRole.m
@@ -81,4 +81,17 @@
     return [self.name isEqualToString:anotherRole.name];
 }
 
+#pragma mark - NSCoding
+
+- (void)encodeWithCoder:(NSCoder *)aCoder
+{
+    [aCoder encodeObject:self.name forKey:@"name"];
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder
+{
+    return
+        [[self class] roleWithName:[aDecoder decodeObjectOfClass:[NSString class] forKey:@"name"]];
+}
+
 @end


### PR DESCRIPTION
This fixes the problem that SKYRecord does not correctly handle
metadata fields for serialization and copying. The SqliteStore
of SKYRecordStorage is also updated to use JSON serialization
which should be more robust than relying on NSKeyedArchiver.

connects #36
connects #30