### PR TITLE
Expose -[SKYNotification subscriptionID]

### DIFF
--- a/Pod/Classes/SKYNotification.h
+++ b/Pod/Classes/SKYNotification.h
@@ -34,6 +34,7 @@ typedef enum SKYNotificationType : NSInteger {
 @property (nonatomic, readonly, copy) SKYNotificationID *notificationID;
 @property (nonatomic, readonly, assign) SKYNotificationType notificationType;
 @property (nonatomic, readonly, copy) NSString *containerIdentifier;
+@property (nonatomic, readonly, copy) NSString *subscriptionID;
 
 @property (nonatomic, readonly, assign) BOOL isPruned;
 

--- a/Pod/Classes/SKYNotification.m
+++ b/Pod/Classes/SKYNotification.m
@@ -31,7 +31,7 @@
         // we only have query notification at the moment
         self.notificationType = SKYNotificationTypeQuery;
 
-        self.subscriptionID = subscriptionID;
+        self.subscriptionID = [subscriptionID copy];
     }
     return self;
 }


### PR DESCRIPTION
The subscription ID is stored in a SKYNotification but it is only
exposed via a private header. This commit exposes the property in
public header.

connects skygeario/skygear-SDK-iOS#41