### PR TITLE
Persist current user information

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -25,14 +25,14 @@ PODS:
   - OHHTTPStubs/NSURLSession (4.6.0):
     - OHHTTPStubs/Core
   - OHHTTPStubs/OHPathHelpers (4.6.0)
-  - SKYKit (0.16.0):
-    - SKYKit/Core (= 0.16.0)
-  - SKYKit/Chat (0.16.0):
+  - SKYKit (0.17.0):
+    - SKYKit/Core (= 0.17.0)
+  - SKYKit/Chat (0.17.0):
     - SKYKit/Core
-  - SKYKit/Core (0.16.0):
+  - SKYKit/Core (0.17.0):
     - FMDB (~> 2.5)
     - SocketRocket (~> 0.4)
-  - SKYKit/Facebook (0.16.0):
+  - SKYKit/Facebook (0.17.0):
     - FBSDKCoreKit (~> 4.0)
     - SKYKit/Core
   - SocketRocket (0.5.1)
@@ -49,7 +49,7 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   SKYKit:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
   Bolts: a0058fa3b331c5a1e4402d534f2dae36dbff31e4
@@ -58,7 +58,7 @@ SPEC CHECKSUMS:
   FMDB: 854a0341b4726e53276f2a8996f06f1b80f9259a
   OCMock: 28def049ef47f996b515a8eeea958be7ccab2dbb
   OHHTTPStubs: cb1aefbbeb4de4e741644455d4b945538e5248a2
-  SKYKit: 87a8c39b223a89e7bbc7d764514e70b492e49855
+  SKYKit: 56fe4b349881499a721e95d26fbe94922f42be26
   SocketRocket: d57c7159b83c3c6655745cd15302aa24b6bae531
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
 

--- a/Example/Swift Example/View Controllers/UserAuthenticationViewController.swift
+++ b/Example/Swift Example/View Controllers/UserAuthenticationViewController.swift
@@ -224,7 +224,11 @@ class UserAuthenticationViewController: UITableViewController {
             let cell = tableView.dequeueReusableCellWithIdentifier("plain", forIndexPath: indexPath)
             if indexPath.row == 0 {
                 cell.textLabel?.text = "Username"
-                cell.detailTextLabel?.text = SKYContainer.defaultContainer().currentUser.username
+                if let user = SKYContainer.defaultContainer().currentUser {
+                    cell.detailTextLabel?.text = user.username
+                } else {
+                    cell.detailTextLabel?.text = "(Unavailable)"
+                }
             } else if indexPath.row == 1 {
                 cell.textLabel?.text = "User Record ID"
                 cell.detailTextLabel?.text = SKYContainer.defaultContainer().currentUserRecordID
@@ -233,19 +237,27 @@ class UserAuthenticationViewController: UITableViewController {
                 cell.detailTextLabel?.text = SKYContainer.defaultContainer().currentAccessToken.tokenString
             } else if indexPath.row == 3 {
                 cell.textLabel?.text = "Last Login At"
-                if let lastLoginAt = SKYContainer.defaultContainer().currentUser.lastLoginAt {
-                    let f = self.dateFormatter.stringFromDate(lastLoginAt)
-                    cell.detailTextLabel?.text = f
+                if let user = SKYContainer.defaultContainer().currentUser {
+                    if let lastLoginAt = user.lastLoginAt {
+                        let f = self.dateFormatter.stringFromDate(lastLoginAt)
+                        cell.detailTextLabel?.text = f
+                    } else {
+                        cell.detailTextLabel?.text = "Querying..."
+                    }
                 } else {
-                    cell.detailTextLabel?.text = "Querying..."
+                    cell.detailTextLabel?.text = "(Unavailable)"
                 }
             } else if indexPath.row == 4 {
                 cell.textLabel?.text = "Last Seen At"
-                if let lastSeenAt = SKYContainer.defaultContainer().currentUser.lastSeenAt {
-                    let f = self.dateFormatter.stringFromDate(lastSeenAt)
-                    cell.detailTextLabel?.text = f
+                if let user = SKYContainer.defaultContainer().currentUser {
+                    if let lastSeenAt = user.lastSeenAt {
+                        let f = self.dateFormatter.stringFromDate(lastSeenAt)
+                        cell.detailTextLabel?.text = f
+                    } else {
+                        cell.detailTextLabel?.text = "Querying..."
+                    }
                 } else {
-                    cell.detailTextLabel?.text = "Querying..."
+                    cell.detailTextLabel?.text = "(Unavailable)"
                 }
             }
             return cell

--- a/Example/Swift Example/View Controllers/UserAuthenticationViewController.swift
+++ b/Example/Swift Example/View Controllers/UserAuthenticationViewController.swift
@@ -24,8 +24,6 @@ class UserAuthenticationViewController: UITableViewController {
     
     let actionSectionIndex = 0
     let statusSectionIndex = 1
-    var lastLoginAt : NSDate?
-    var lastSeenAt : NSDate?
     
     let dateFormatter = NSDateFormatter()
     
@@ -36,7 +34,6 @@ class UserAuthenticationViewController: UITableViewController {
         set(value) {
             NSUserDefaults.standardUserDefaults().setObject(value, forKey: "LastUsername")
             NSUserDefaults.standardUserDefaults().synchronize()
-            self.loginStatusDidChange()
         }
     }
     
@@ -88,15 +85,14 @@ class UserAuthenticationViewController: UITableViewController {
                 })
                 return
             }
-            
-            self.lastUsername = user.username
-            self.lastLoginAt = user.lastLoginAt
-            self.lastSeenAt = user.lastSeenAt
-
         }
     }
     
     func loginStatusDidChange() {
+        if let user = SKYContainer.defaultContainer().currentUser {
+            self.lastUsername = user.username
+        }
+        
         self.tableView.reloadData()
     }
     
@@ -126,10 +122,6 @@ class UserAuthenticationViewController: UITableViewController {
                     })
                     return
                 }
-                
-                self.lastUsername = username
-                self.lastLoginAt = user.lastLoginAt
-                self.lastSeenAt = user.lastSeenAt
             })
         }))
         alert.preferredAction = alert.actions.last
@@ -161,8 +153,6 @@ class UserAuthenticationViewController: UITableViewController {
                     })
                     return
                 }
-                
-                self.lastUsername = username
             })
         }))
         alert.preferredAction = alert.actions.last
@@ -234,7 +224,7 @@ class UserAuthenticationViewController: UITableViewController {
             let cell = tableView.dequeueReusableCellWithIdentifier("plain", forIndexPath: indexPath)
             if indexPath.row == 0 {
                 cell.textLabel?.text = "Username"
-                cell.detailTextLabel?.text = self.lastUsername
+                cell.detailTextLabel?.text = SKYContainer.defaultContainer().currentUser.username
             } else if indexPath.row == 1 {
                 cell.textLabel?.text = "User Record ID"
                 cell.detailTextLabel?.text = SKYContainer.defaultContainer().currentUserRecordID
@@ -243,7 +233,7 @@ class UserAuthenticationViewController: UITableViewController {
                 cell.detailTextLabel?.text = SKYContainer.defaultContainer().currentAccessToken.tokenString
             } else if indexPath.row == 3 {
                 cell.textLabel?.text = "Last Login At"
-                if let lastLoginAt = self.lastLoginAt {
+                if let lastLoginAt = SKYContainer.defaultContainer().currentUser.lastLoginAt {
                     let f = self.dateFormatter.stringFromDate(lastLoginAt)
                     cell.detailTextLabel?.text = f
                 } else {
@@ -251,7 +241,7 @@ class UserAuthenticationViewController: UITableViewController {
                 }
             } else if indexPath.row == 4 {
                 cell.textLabel?.text = "Last Seen At"
-                if let lastSeenAt = self.lastSeenAt {
+                if let lastSeenAt = SKYContainer.defaultContainer().currentUser.lastSeenAt {
                     let f = self.dateFormatter.stringFromDate(lastSeenAt)
                     cell.detailTextLabel?.text = f
                 } else {

--- a/Example/Tests/SKYContainerTests.m
+++ b/Example/Tests/SKYContainerTests.m
@@ -82,6 +82,8 @@ describe(@"user login and signup", ^{
     __block void (^assertLoggedIn)(NSString *, NSError *) =
         ^(NSString *userRecordID, NSError *error) {
             expect(container.currentUserRecordID).to.equal(userRecordID);
+            expect(container.currentUser.username).to.equal(@"john.doe");
+            expect(container.currentUser.email).to.equal(@"john.doe@example.com");
             expect(error).to.beNil();
             expect(userRecordID).to.equal(@"UUID");
             expect(container.currentAccessToken.tokenString).to.equal(@"ACCESS_TOKEN");
@@ -96,6 +98,8 @@ describe(@"user login and signup", ^{
             withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
                 NSDictionary *parameters = @{
                     @"user_id" : @"UUID",
+                    @"username" : @"john.doe",
+                    @"email" : @"john.doe@example.com",
                     @"access_token" : @"ACCESS_TOKEN",
                 };
                 NSData *payload = [NSJSONSerialization dataWithJSONObject:@{
@@ -261,7 +265,7 @@ describe(@"save current user", ^{
         });
     });
 
-    it(@"fetch record", ^{
+    it(@"fetch user with ID", ^{
         SKYContainer *container = [[SKYContainer alloc] init];
         [container
             updateWithUserRecordID:@"user1"
@@ -272,12 +276,36 @@ describe(@"save current user", ^{
         expect(container.currentAccessToken.tokenString).to.equal(@"accesstoken1");
     });
 
-    it(@"update with nil", ^{
+    it(@"fetch user with User", ^{
+        SKYContainer *container = [[SKYContainer alloc] init];
+        SKYUser *user = [SKYUser userWithUserID:@"user1"];
+        user.username = @"username1";
+        [container updateWithUser:user
+                      accessToken:[[SKYAccessToken alloc] initWithTokenString:@"accesstoken1"]];
+
+        container = [[SKYContainer alloc] init];
+        expect(container.currentUserRecordID).to.equal(@"user1");
+        expect(container.currentUser.username).to.equal(@"username1");
+        expect(container.currentAccessToken.tokenString).to.equal(@"accesstoken1");
+    });
+
+    it(@"update with nil ID", ^{
         SKYContainer *container = [[SKYContainer alloc] init];
         [container updateWithUserRecordID:nil accessToken:nil];
 
         container = [[SKYContainer alloc] init];
         expect(container.currentUserRecordID).to.beNil();
+        expect(container.currentUser).to.beNil();
+        expect(container.currentAccessToken).to.beNil();
+    });
+
+    it(@"update with nil User", ^{
+        SKYContainer *container = [[SKYContainer alloc] init];
+        [container updateWithUser:nil accessToken:nil];
+
+        container = [[SKYContainer alloc] init];
+        expect(container.currentUserRecordID).to.beNil();
+        expect(container.currentUser).to.beNil();
         expect(container.currentAccessToken).to.beNil();
     });
 

--- a/Example/Tests/SKYUserDeserializerTests.m
+++ b/Example/Tests/SKYUserDeserializerTests.m
@@ -92,6 +92,23 @@ SpecBegin(SKYUserDeserializerTests)
             expect([user hasRole:[SKYRole roleWithName:@"Developer"]]).to.equal(YES);
         });
 
+        it(@"should be initialized correctly with meta date", ^{
+            NSDictionary *response = @{
+                @"user_id" : @"userid1",
+                @"username" : @"User 1",
+                @"email" : @"user1@example.com",
+                @"last_login_at" : @"2016-09-08T06:45:59.000Z",
+                @"last_seen_at" : @"2016-09-08T06:45:59.000Z"
+            };
+
+            SKYUser *user1 = [deserializer userWithDictionary:response];
+            expect(user1.userID).to.equal(@"userid1");
+            expect(user1.username).to.equal(@"User 1");
+            expect(user1.email).to.equal(@"user1@example.com");
+            expect(user1.lastLoginAt).notTo.beNil();
+            expect(user1.lastSeenAt).notTo.beNil();
+        });
+
     });
 
 SpecEnd

--- a/Example/Tests/SKYUserTests.m
+++ b/Example/Tests/SKYUserTests.m
@@ -33,22 +33,6 @@ SpecBegin(SKYUser)
             expect(user2.userID).to.equal(@"user_id2");
         });
 
-        it(@"should be initialized correctly with meta date", ^{
-            NSDictionary *response = @{
-                @"user_id" : @"userid1",
-                @"username" : @"User 1",
-                @"email" : @"user1@example.com",
-                @"last_login_at" : @"2016-09-08T06:45:59.000Z",
-                @"last_seen_at" : @"2016-09-08T06:45:59.000Z"
-            };
-            SKYUser *user1 = [SKYUser userWithResponse:response];
-            expect(user1.userID).to.equal(@"userid1");
-            expect(user1.username).to.equal(@"User 1");
-            expect(user1.email).to.equal(@"user1@example.com");
-            expect(user1.lastLoginAt).notTo.beNil();
-            expect(user1.lastSeenAt).notTo.beNil();
-        });
-
         it(@"should manipulate roles correctly", ^{
             SKYRole *developerRole = [SKYRole roleWithName:@"Developer"];
             SKYRole *testerRole = [SKYRole roleWithName:@"Tester"];

--- a/Example/Tests/SKYUserTests.m
+++ b/Example/Tests/SKYUserTests.m
@@ -54,6 +54,30 @@ SpecBegin(SKYUser)
             expect(user.roles).to.haveACountOf(2);
             expect([user hasRole:testerRole]).to.equal(NO);
         });
+
+        it(@"should encode and decode correctly", ^{
+            SKYRole *developerRole = [SKYRole roleWithName:@"Developer"];
+            SKYRole *testerRole = [SKYRole roleWithName:@"Tester"];
+
+            SKYUser *user = [SKYUser userWithUserID:@"user_id"];
+            user.username = @"username";
+            user.email = @"username@example.com";
+            user.lastLoginAt = [NSDate date];
+            user.lastSeenAt = [NSDate date];
+            user.roles = @[ developerRole, testerRole ];
+
+            NSData *encodedUser = [NSKeyedArchiver archivedDataWithRootObject:user];
+            SKYUser *decodedUser = [NSKeyedUnarchiver unarchiveObjectWithData:encodedUser];
+
+            expect(decodedUser.userID).to.equal(user.userID);
+            expect(decodedUser.username).to.equal(user.username);
+            expect(decodedUser.email).to.equal(user.email);
+            expect(decodedUser.lastLoginAt).to.equal(user.lastLoginAt);
+            expect(decodedUser.lastSeenAt).to.equal(user.lastSeenAt);
+            expect(decodedUser.roles[0].name).to.equal(user.roles[0].name);
+            expect(decodedUser.roles[1].name).to.equal(user.roles[1].name);
+        });
+
     });
 
 SpecEnd

--- a/Example/Tests/SKYUserTests.m
+++ b/Example/Tests/SKYUserTests.m
@@ -19,6 +19,8 @@
 
 #import <SKYKit/SKYKit.h>
 
+#import "SKYUser_Private.h"
+
 SpecBegin(SKYUser)
 
     describe(@"SKYUser", ^{

--- a/Pod/Classes/Operations/SKYGetCurrentUserOperation.m
+++ b/Pod/Classes/Operations/SKYGetCurrentUserOperation.m
@@ -19,6 +19,7 @@
 
 #import "SKYGetCurrentUserOperation.h"
 #import "SKYOperationSubclass.h"
+#import "SKYUserDeserializer.h"
 
 @interface SKYGetCurrentUserOperation ()
 
@@ -57,7 +58,7 @@
             accessToken =
                 [[SKYAccessToken alloc] initWithTokenString:resultDictionary[@"access_token"]];
 
-            user = [SKYUser userWithResponse:resultDictionary];
+            user = [[SKYUserDeserializer deserializer] userWithDictionary:resultDictionary];
         } else {
             error = [self.errorCreator errorWithCode:SKYErrorBadResponse
                                              message:@"Get a non-user object is received."];

--- a/Pod/Classes/Operations/SKYGetCurrentUserOperation.m
+++ b/Pod/Classes/Operations/SKYGetCurrentUserOperation.m
@@ -58,15 +58,6 @@
                 [[SKYAccessToken alloc] initWithTokenString:resultDictionary[@"access_token"]];
 
             user = [SKYUser userWithResponse:resultDictionary];
-
-            NSMutableArray<SKYRole *> *roles = [[NSMutableArray alloc] init];
-            NSArray<NSString *> *roleNames = resultDictionary[@"roles"];
-            [roleNames
-                enumerateObjectsUsingBlock:^(NSString *perRoleName, NSUInteger idx, BOOL *stop) {
-                    [roles addObject:[SKYRole roleWithName:perRoleName]];
-                }];
-
-            user.roles = roles;
         } else {
             error = [self.errorCreator errorWithCode:SKYErrorBadResponse
                                              message:@"Get a non-user object is received."];

--- a/Pod/Classes/Operations/SKYLoginUserOperation.m
+++ b/Pod/Classes/Operations/SKYLoginUserOperation.m
@@ -21,6 +21,7 @@
 #import "SKYOperationSubclass.h"
 #import "SKYOperation_Private.h"
 #import "SKYRequest.h"
+#import "SKYUserDeserializer.h"
 
 @implementation SKYLoginUserOperation {
     NSDictionary *_authPayload;
@@ -116,7 +117,7 @@
 
     NSDictionary *response = aResponse.responseDictionary[@"result"];
     if (response[@"user_id"] && response[@"access_token"]) {
-        user = [SKYUser userWithResponse:response];
+        user = [[SKYUserDeserializer deserializer] userWithDictionary:response];
         accessToken = [[SKYAccessToken alloc] initWithTokenString:response[@"access_token"]];
     } else {
         error = [self.errorCreator errorWithCode:SKYErrorBadResponse

--- a/Pod/Classes/Operations/SKYLoginUserOperation.m
+++ b/Pod/Classes/Operations/SKYLoginUserOperation.m
@@ -117,15 +117,6 @@
     NSDictionary *response = aResponse.responseDictionary[@"result"];
     if (response[@"user_id"] && response[@"access_token"]) {
         user = [SKYUser userWithResponse:response];
-
-        NSMutableArray<SKYRole *> *roles = [[NSMutableArray alloc] init];
-        NSArray<NSString *> *roleNames = response[@"roles"];
-        [roleNames enumerateObjectsUsingBlock:^(NSString *perRoleName, NSUInteger idx, BOOL *stop) {
-            [roles addObject:[SKYRole roleWithName:perRoleName]];
-        }];
-
-        user.roles = roles;
-
         accessToken = [[SKYAccessToken alloc] initWithTokenString:response[@"access_token"]];
     } else {
         error = [self.errorCreator errorWithCode:SKYErrorBadResponse

--- a/Pod/Classes/Operations/SKYSignupUserOperation.m
+++ b/Pod/Classes/Operations/SKYSignupUserOperation.m
@@ -112,15 +112,6 @@
 
                 SKYUser *user = [SKYUser userWithResponse:response];
 
-                NSMutableArray<SKYRole *> *roles = [[NSMutableArray alloc] init];
-                NSArray<NSString *> *roleNames = response[@"roles"];
-                [roleNames enumerateObjectsUsingBlock:^(NSString *perRoleName, NSUInteger idx,
-                                                        BOOL *stop) {
-                    [roles addObject:[SKYRole roleWithName:perRoleName]];
-                }];
-
-                user.roles = roles;
-
                 SKYAccessToken *accessToken =
                     [[SKYAccessToken alloc] initWithTokenString:response[@"access_token"]];
 

--- a/Pod/Classes/Operations/SKYSignupUserOperation.m
+++ b/Pod/Classes/Operations/SKYSignupUserOperation.m
@@ -20,6 +20,7 @@
 #import "SKYSignupUserOperation.h"
 #import "SKYOperation_Private.h"
 #import "SKYRequest.h"
+#import "SKYUserDeserializer.h"
 
 @implementation SKYSignupUserOperation
 
@@ -110,7 +111,7 @@
             if (!weakSelf.error) {
                 NSDictionary *response = weakSelf.response[@"result"];
 
-                SKYUser *user = [SKYUser userWithResponse:response];
+                SKYUser *user = [[SKYUserDeserializer deserializer] userWithDictionary:response];
 
                 SKYAccessToken *accessToken =
                     [[SKYAccessToken alloc] initWithTokenString:response[@"access_token"]];

--- a/Pod/Classes/SKYContainer.h
+++ b/Pod/Classes/SKYContainer.h
@@ -66,6 +66,7 @@ typedef void (^SKYContainerUserOperationActionCompletion)(SKYUser *user, NSError
 
 @property (nonatomic, readonly) NSString *currentUserRecordID;
 @property (nonatomic, readonly) SKYAccessToken *currentAccessToken;
+@property (nonatomic, readonly) SKYUser *currentUser;
 
 @property (nonatomic, strong) SKYPubsub *pubsubClient;
 
@@ -106,10 +107,18 @@ typedef void (^SKYContainerUserOperationActionCompletion)(SKYUser *user, NSError
  This method is called when operation sign up, log in and log out is performed using the container's
  convenient
  method and when the operation is completed successfully.
-
- @see -loadAccessCurrentUserRecordIDAndAccessToken
  */
 - (void)updateWithUserRecordID:(NSString *)userRecordID accessToken:(SKYAccessToken *)accessToken;
+
+/**
+ Updates the <currentUser> and <currentAccessToken>. The updated access credentials are also
+ stored in persistent storage.
+
+ This method is called when operation sign up, log in and log out is performed using the container's
+ convenient
+ method and when the operation is completed successfully.
+ */
+- (void)updateWithUser:(SKYUser *)user accessToken:(SKYAccessToken *)accessToken;
 
 /**
  Set the handler to be called when SKYOperation's subclasses failed to authenticate itself with

--- a/Pod/Classes/SKYContainer_Private.h
+++ b/Pod/Classes/SKYContainer_Private.h
@@ -29,7 +29,7 @@
  This method is called when <SKYContainer> is `-init` is called. You should not call this method
  manually.
  */
-- (void)loadAccessCurrentUserRecordIDAndAccessToken;
+- (void)loadCurrentUserAndAccessToken;
 
 - (void)performUserAuthOperation:(SKYOperation *)operation
                completionHandler:(SKYContainerUserOperationActionCompletion)completionHandler;

--- a/Pod/Classes/SKYUser.h
+++ b/Pod/Classes/SKYUser.h
@@ -33,7 +33,7 @@
 - (BOOL)hasRole:(SKYRole *)aRole;
 
 + (instancetype)userWithUserID:(NSString *)userID;
-+ (instancetype)userWithResponse:(NSDictionary *)userID;
++ (instancetype)userWithResponse:(NSDictionary *)userID __deprecated;
 
 @property (nonatomic, copy) NSString *username;
 @property (nonatomic, copy) NSString *email;

--- a/Pod/Classes/SKYUser.h
+++ b/Pod/Classes/SKYUser.h
@@ -40,7 +40,7 @@
 @property (nonatomic, copy) NSDate *lastLoginAt;
 @property (nonatomic, copy) NSDate *lastSeenAt;
 @property (nonatomic, copy) NSDictionary *authData;
-@property (nonatomic, strong) NSArray<SKYRole *> *roles;
+@property (nonatomic, readonly, copy) NSArray<SKYRole *> *roles;
 @property (nonatomic, readonly, assign) BOOL isNew;
 
 @property (nonatomic, readonly, copy) NSString *userID;

--- a/Pod/Classes/SKYUser.h
+++ b/Pod/Classes/SKYUser.h
@@ -23,7 +23,7 @@
 @class SKYQueryCursor;
 @class SKYQueryOperation;
 
-@interface SKYUser : NSObject
+@interface SKYUser : NSObject <NSCoding>
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithUserID:(NSString *)userID;

--- a/Pod/Classes/SKYUser.m
+++ b/Pod/Classes/SKYUser.m
@@ -42,6 +42,16 @@
     user.username = response[@"username"];
     user.lastLoginAt = [SKYDataSerialization dateFromString:response[@"last_login_at"]];
     user.lastSeenAt = [SKYDataSerialization dateFromString:response[@"last_seen_at"]];
+    
+    // Parse roles
+    NSMutableArray<SKYRole *> *roles = [[NSMutableArray alloc] init];
+    NSArray<NSString *> *roleNames = response[@"roles"];
+    [roleNames
+     enumerateObjectsUsingBlock:^(NSString *perRoleName, NSUInteger idx, BOOL *stop) {
+         [roles addObject:[SKYRole roleWithName:perRoleName]];
+     }];
+    user->_roles = [roles copy];
+    
     return user;
 }
 

--- a/Pod/Classes/SKYUser.m
+++ b/Pod/Classes/SKYUser.m
@@ -48,6 +48,35 @@
     return self;
 }
 
+- (instancetype)initWithCoder:(NSCoder *)aDecoder
+{
+    NSString *userID = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"userID"];
+    if (!userID) {
+        return nil;
+    }
+
+    self = [self initWithUserID:userID];
+    if (self) {
+        _username = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"username"];
+        _email = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"email"];
+        _lastLoginAt = [aDecoder decodeObjectOfClass:[NSDate class] forKey:@"lastLoginAt"];
+        _lastSeenAt = [aDecoder decodeObjectOfClass:[NSDate class] forKey:@"lastSeenAt"];
+        _roles = [[aDecoder decodeObjectOfClass:[NSArray class] forKey:@"roles"] mutableCopy];
+    }
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder
+{
+    // authData is specifically not persisted because of unclear security implications.
+    [aCoder encodeObject:_userID forKey:@"userID"];
+    [aCoder encodeObject:_username forKey:@"username"];
+    [aCoder encodeObject:_email forKey:@"email"];
+    [aCoder encodeObject:_lastLoginAt forKey:@"lastLoginAt"];
+    [aCoder encodeObject:_lastSeenAt forKey:@"lastSeenAt"];
+    [aCoder encodeObject:[_roles copy] forKey:@"roles"];
+}
+
 - (NSArray<SKYRole *> *)roles
 {
     return [_roles copy];

--- a/Pod/Classes/SKYUser.m
+++ b/Pod/Classes/SKYUser.m
@@ -19,16 +19,13 @@
 
 #import "SKYUser.h"
 #import "SKYDataSerialization.h"
+#import "SKYUser_Private.h"
 
 #import "SKYQueryOperation.h"
 
-@interface SKYUser ()
-
-@property (nonatomic, readwrite, copy) NSString *recordID;
-
-@end
-
-@implementation SKYUser
+@implementation SKYUser {
+    NSMutableArray<SKYRole *> *_roles;
+}
 
 + (instancetype)userWithUserID:(NSString *)userID
 {
@@ -50,7 +47,7 @@
      enumerateObjectsUsingBlock:^(NSString *perRoleName, NSUInteger idx, BOOL *stop) {
          [roles addObject:[SKYRole roleWithName:perRoleName]];
      }];
-    user->_roles = [roles copy];
+    user->_roles = roles;
     
     return user;
 }
@@ -60,17 +57,25 @@
     self = [super init];
     if (self) {
         _userID = [userID copy];
+        _roles = [NSMutableArray array];
     }
     return self;
+}
+
+- (NSArray<SKYRole *> *)roles
+{
+    return [_roles copy];
+}
+
+- (void)setRoles:(NSArray *)roles
+{
+    _roles = [roles mutableCopy];
 }
 
 - (void)addRole:(SKYRole *)aRole
 {
     if (![self hasRole:aRole]) {
-        NSMutableArray<SKYRole *> *roles = [self.roles mutableCopy];
-        [roles addObject:aRole];
-
-        [self setRoles:roles];
+        [_roles addObject:aRole];
     }
 }
 
@@ -78,10 +83,7 @@
 {
     NSUInteger idx = [self indexOfRole:aRole];
     if (idx != NSNotFound) {
-        NSMutableArray<SKYRole *> *roles = [self.roles mutableCopy];
-        [roles removeObjectAtIndex:idx];
-
-        [self setRoles:roles];
+        [_roles removeObjectAtIndex:idx];
     }
 }
 

--- a/Pod/Classes/SKYUser.m
+++ b/Pod/Classes/SKYUser.m
@@ -19,6 +19,7 @@
 
 #import "SKYUser.h"
 #import "SKYDataSerialization.h"
+#import "SKYUserDeserializer.h"
 #import "SKYUser_Private.h"
 
 #import "SKYQueryOperation.h"
@@ -34,22 +35,7 @@
 
 + (instancetype)userWithResponse:(NSDictionary *)response
 {
-    SKYUser *user = [SKYUser userWithUserID:response[@"user_id"]];
-    user.email = response[@"email"];
-    user.username = response[@"username"];
-    user.lastLoginAt = [SKYDataSerialization dateFromString:response[@"last_login_at"]];
-    user.lastSeenAt = [SKYDataSerialization dateFromString:response[@"last_seen_at"]];
-    
-    // Parse roles
-    NSMutableArray<SKYRole *> *roles = [[NSMutableArray alloc] init];
-    NSArray<NSString *> *roleNames = response[@"roles"];
-    [roleNames
-     enumerateObjectsUsingBlock:^(NSString *perRoleName, NSUInteger idx, BOOL *stop) {
-         [roles addObject:[SKYRole roleWithName:perRoleName]];
-     }];
-    user->_roles = roles;
-    
-    return user;
+    return [[SKYUserDeserializer deserializer] userWithDictionary:response];
 }
 
 - (instancetype)initWithUserID:(NSString *)userID

--- a/Pod/Classes/SKYUser_Private.h
+++ b/Pod/Classes/SKYUser_Private.h
@@ -1,0 +1,27 @@
+//
+//  SKYUser_Private.h
+//  SKYKit
+//
+//  Copyright 2015 Oursky Ltd.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "SKYUser.h"
+
+@interface SKYUser ()
+
+@property (nonatomic, readwrite, copy) NSString *recordID;
+@property (nonatomic, readwrite, copy) NSArray *roles;
+
+@end


### PR DESCRIPTION
User information (`SKYUser`) is now persisted to `NSUserDefaults` when `SKYContainer`
current user changes. This will happen automatically after user authentication
operations.

connects #49