### PR TITLE
Fix unable to upload asset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ cache:
 - pip
 before_install:
 - gem install --no-rdoc --no-ri 'cocoapods:1.1.1'
+- brew update
 - brew install clang-format
+- clang-format --version
 - brew install swiftlint
 - sudo pip install lizard
 - pod install --project-directory=Example

--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,7 @@ docs:
 .PHONY: clean-docs
 clean-docs:
 	-rm docs
+
+.PHONY: format
+format:
+	./clang-check.sh fix

--- a/Pod/Classes/SKYAsset.h
+++ b/Pod/Classes/SKYAsset.h
@@ -35,6 +35,8 @@
 @property (nonatomic, readonly, copy) NSString *name;
 /// Undocumented
 @property (nonatomic, readonly, copy) NSURL *url;
+/// Undocumented
+@property (nonatomic, readonly, copy) NSNumber *fileSize;
 
 /**
  The MIME type of the asset when the MIME type is known.

--- a/Pod/Classes/SKYAsset_Private.h
+++ b/Pod/Classes/SKYAsset_Private.h
@@ -27,6 +27,5 @@
 
 @property (nonatomic, readwrite, copy) NSString *name;
 @property (nonatomic, readwrite, copy) NSURL *url;
-@property (nonatomic, readonly, copy) NSNumber *fileSize;
 
 @end

--- a/Pod/Classes/SKYContainer.m
+++ b/Pod/Classes/SKYContainer.m
@@ -737,6 +737,20 @@ NSString *const SKYContainerDidRegisterDeviceNotification =
 {
     __weak typeof(self) wself = self;
 
+    if ([asset.fileSize integerValue] == 0) {
+        if (completionHandler) {
+            completionHandler(
+                nil, [NSError errorWithDomain:SKYOperationErrorDomain
+                                         code:SKYErrorInvalidArgument
+                                     userInfo:@{
+                                         SKYErrorMessageKey : @"File size is invalid (filesize=0).",
+                                         NSLocalizedDescriptionKey : NSLocalizedString(
+                                             @"Unable to open file or file is not found.", nil)
+                                     }]);
+        }
+        return;
+    }
+
     SKYGetAssetPostRequestOperation *operation =
         [SKYGetAssetPostRequestOperation operationWithAsset:asset];
     operation.getAssetPostRequestCompletionBlock = ^(

--- a/Pod/Classes/SKYGetAssetPostRequestOperation.m
+++ b/Pod/Classes/SKYGetAssetPostRequestOperation.m
@@ -67,9 +67,13 @@
 {
     NSDictionary *result = response.responseDictionary[@"result"];
 
-    [self.asset setName:result[@"asset"][@"$name"]];
-    [self.asset setUrl:result[@"asset"][@"$url"]];
-    [self.asset setMimeType:result[@"asset"][@"$content_type"]];
+    // Update the asset name with the generated name obtained from the server.
+    // Note: Do not update the URL of the asset here because the file is not
+    // uploaded to the server yet.
+    NSString *assetName = result[@"asset"][@"$name"];
+    if ([assetName isKindOfClass:[NSString class]] || assetName == nil) {
+        self.asset.name = assetName;
+    }
 
     NSDictionary *rawPostRequest = result[@"post-request"];
     NSDictionary *extraFields = rawPostRequest[@"extra-fields"];


### PR DESCRIPTION
This happens because when obtaining a post URL from the server, the
asset.url property is overwrite with server data. This change copies the
asset object so that the file URL in the asset object can be used to upload
the file to the server.

The SDK also blocks the client from trying to upload if the file has
zero size.

connects #100