### PR TITLE
Fix unable to upload asset

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -25,12 +25,12 @@ PODS:
   - OHHTTPStubs/NSURLSession (4.6.0):
     - OHHTTPStubs/Core
   - OHHTTPStubs/OHPathHelpers (4.6.0)
-  - SKYKit (0.22.1):
-    - SKYKit/Core (= 0.22.1)
-  - SKYKit/Core (0.22.1):
+  - SKYKit (0.24.0):
+    - SKYKit/Core (= 0.24.0)
+  - SKYKit/Core (0.24.0):
     - FMDB (~> 2.5)
     - SocketRocket (~> 0.4)
-  - SKYKit/Facebook (0.22.1):
+  - SKYKit/Facebook (0.24.0):
     - FBSDKCoreKit (~> 4.0)
     - SKYKit/Core
   - SocketRocket (0.5.1)
@@ -55,7 +55,7 @@ SPEC CHECKSUMS:
   FMDB: 854a0341b4726e53276f2a8996f06f1b80f9259a
   OCMock: 28def049ef47f996b515a8eeea958be7ccab2dbb
   OHHTTPStubs: cb1aefbbeb4de4e741644455d4b945538e5248a2
-  SKYKit: 8bc0f984c4e99f03dc9f0881bd431c14f4aeeafe
+  SKYKit: 7232e3c0cb269ae035f4bd2b6cea899e964cea6a
   SocketRocket: d57c7159b83c3c6655745cd15302aa24b6bae531
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
 

--- a/Example/SKYKit.xcodeproj/project.pbxproj
+++ b/Example/SKYKit.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		CDF571031AB4825700091DB3 /* SKYQuerySerializerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CDF571021AB4825700091DB3 /* SKYQuerySerializerTests.m */; };
 		CF234C631E8AB08600BF4E0F /* SKYDefineDefaultAccessOperationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CF234C621E8AB08600BF4E0F /* SKYDefineDefaultAccessOperationTests.m */; };
 		DF862921DB633F3364419993 /* Pods_Swift_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA35E28666BD02136512A2B5 /* Pods_Swift_Example.framework */; };
+		F413CD5C1ED6BBE2001EBFAB /* SKYAssetTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F413CD5B1ED6BBE2001EBFAB /* SKYAssetTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -213,6 +214,7 @@
 		DA35E28666BD02136512A2B5 /* Pods_Swift_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Swift_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E14141B974E77B52FC7F22EF /* Pods-SKYKit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SKYKit.release.xcconfig"; path = "Pods/Target Support Files/Pods-SKYKit/Pods-SKYKit.release.xcconfig"; sourceTree = "<group>"; };
 		E61967EA35930CACEBEC4FC6 /* Pods-Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Tests/Pods-Tests.release.xcconfig"; sourceTree = "<group>"; };
+		F413CD5B1ED6BBE2001EBFAB /* SKYAssetTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SKYAssetTests.m; sourceTree = "<group>"; };
 		FBC0F6D83E10A7B47F5417C2 /* Pods-Swift Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Swift Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-Swift Example/Pods-Swift Example.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -411,6 +413,7 @@
 				37B10B1B1B1C5F0400052740 /* SKYUserDeserializerTests.m */,
 				6031B9751C7D71C700132DED /* SKYUserTests.m */,
 				6003F5B6195388D20070C39A /* Supporting Files */,
+				F413CD5B1ED6BBE2001EBFAB /* SKYAssetTests.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -951,6 +954,7 @@
 				376CB11D1AE906B600FA0324 /* SKYFetchSubscriptionsOperationTests.m in Sources */,
 				3785584A1AE63FEC00685319 /* SKYSubscriptionSerializerTests.m in Sources */,
 				CD48CE0F1AA06C7900A1CD04 /* SKYModifyRecordsOperationTests.m in Sources */,
+				F413CD5C1ED6BBE2001EBFAB /* SKYAssetTests.m in Sources */,
 				38A115351B02EC4E00D3BAFB /* SKYRecordSynchronizerTests.m in Sources */,
 				CF234C631E8AB08600BF4E0F /* SKYDefineDefaultAccessOperationTests.m in Sources */,
 				CD7FE2721A9EDD5B002C076E /* SKYSignupUserOperationTests.m in Sources */,

--- a/Example/Tests/SKYAssetTests.m
+++ b/Example/Tests/SKYAssetTests.m
@@ -1,0 +1,39 @@
+//
+//  SKYAssetTests.m
+//  SKYKit
+//
+//  Copyright 2017 Oursky Ltd.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+#import <OHHTTPStubs/OHHTTPStubs.h>
+#import <SKYKit/SKYKit.h>
+
+SpecBegin(SKYAsset)
+
+    describe(@"SKYAsset", ^{
+        it(@"copy creates a copy", ^{
+            SKYAsset *asset =
+                [SKYAsset assetWithData:[@"hello-world" dataUsingEncoding:NSUTF8StringEncoding]];
+            SKYAsset *copiedAsset = [asset copy];
+
+            expect(asset.name).to.equal(copiedAsset.name);
+            expect(asset.url).to.equal(copiedAsset.url);
+            expect(asset.mimeType).to.equal(copiedAsset.mimeType);
+            expect(asset.fileSize).to.equal(copiedAsset.fileSize);
+        });
+    });
+
+SpecEnd

--- a/Pod/Classes/SKYAsset.h
+++ b/Pod/Classes/SKYAsset.h
@@ -20,7 +20,7 @@
 #import <Foundation/Foundation.h>
 
 /// Undocumented
-@interface SKYAsset : NSObject
+@interface SKYAsset : NSObject <NSCopying>
 
 /// Undocumented
 + (instancetype)assetWithName:(NSString *)name fileURL:(NSURL *)fileURL;
@@ -43,8 +43,5 @@
  content type.
  */
 @property (nonatomic, readwrite, copy) NSString *mimeType;
-
-/// Undocumented
-- (instancetype)init NS_UNAVAILABLE;
 
 @end


### PR DESCRIPTION
This happens because when obtaining a post URL from the server, the
asset.url property is overwrite with server data. This change copies the
asset object so that the file URL in the asset object can be used to upload
the file to the server.

The SDK also blocks the client from trying to upload if the file has
zero size.

refs #100