### PR TITLE
Make accessControl property on SKYRecord readwrite

### DIFF
--- a/Pod/Classes/SKYAccessControl.m
+++ b/Pod/Classes/SKYAccessControl.m
@@ -26,6 +26,12 @@
 
 @implementation SKYAccessControl
 
++ (instancetype)emptyAccessControl
+{
+    // TODO: ref #96
+    return [SKYAccessControl publicReadableAccessControl];
+}
+
 + (instancetype)publicReadableAccessControl
 {
     return [[self alloc] initWithPublicReadableAccessControl];

--- a/Pod/Classes/SKYAccessControl_Private.h
+++ b/Pod/Classes/SKYAccessControl_Private.h
@@ -22,6 +22,7 @@
 
 @interface SKYAccessControl ()
 
++ (instancetype)emptyAccessControl;
 + (instancetype)publicReadableAccessControl;
 + (instancetype)accessControlWithEntries:(NSArray<SKYAccessControlEntry *> *)entries;
 

--- a/Pod/Classes/SKYRecord.h
+++ b/Pod/Classes/SKYRecord.h
@@ -95,8 +95,10 @@ extern NSString *const SKYRecordTypeUserRecord;
 @property (nonatomic, readonly, copy) NSString *lastModifiedUserRecordID;
 /// Undocumented
 @property (nonatomic, readonly, copy) NSString *recordChangeTag;
-/// Undocumented
-@property (strong, nonatomic, readonly) SKYAccessControl *accessControl;
+/**
+ Gets or sets the access control settings for this record.
+ */
+@property (nonatomic, readwrite, strong, nonnull) SKYAccessControl *accessControl;
 /// Undocumented
 @property (nonatomic, readonly, copy) NSDictionary *dictionary;
 

--- a/Pod/Classes/SKYRecord.m
+++ b/Pod/Classes/SKYRecord.m
@@ -144,6 +144,19 @@ NSString *const SKYRecordTypeUserRecord = @"_User";
     return self.recordID.recordType;
 }
 
+- (void)setAccessControl:(SKYAccessControl *)accessControl
+{
+    _accessControl = accessControl;
+}
+
+- (SKYAccessControl *)getAccessControl
+{
+    if (_accessControl == nil) {
+        _accessControl = [SKYAccessControl emptyAccessControl];
+    }
+    return _accessControl;
+}
+
 #pragma mark - Dictionary-like methods
 
 - (id)objectForKey:(id)key

--- a/Pod/Classes/SKYRecord_Private.h
+++ b/Pod/Classes/SKYRecord_Private.h
@@ -27,6 +27,5 @@
 @property (nonatomic, readwrite, copy) NSString *creatorUserRecordID;
 @property (nonatomic, readwrite, copy) NSDate *modificationDate;
 @property (nonatomic, readwrite, copy) NSString *lastModifiedUserRecordID;
-@property (strong, nonatomic, readwrite) SKYAccessControl *accessControl;
 
 @end


### PR DESCRIPTION
The existing implementation does not work for newly create record
because the access control property is initially null.