### PR TITLE
[SSO] Minor fixes

### DIFF
--- a/Example/Swift Example/View Controllers/OAuthViewController.swift
+++ b/Example/Swift Example/View Controllers/OAuthViewController.swift
@@ -211,11 +211,12 @@ class OAuthViewController: UITableViewController {
 
     func getProviderProfiles() {
         weak var weakSelf = self
-        SKYContainer.default().auth.getOAuthProviderProfiles(selectedProvider) { (result, error) in
+        SKYContainer.default().auth.getOAuthProviderProfiles { (result, error) in
             if error != nil {
                 weakSelf?.showError(error: error)
                 return
             }
+
             guard let data = try? JSONSerialization.data(withJSONObject: result!, options: .prettyPrinted) else {
                 let alert = UIAlertController(title: "Error",
                                               message: "Fail to decode json",

--- a/Pod/Extensions/SSO/SKYAuthContainer+SSO.h
+++ b/Pod/Extensions/SSO/SKYAuthContainer+SSO.h
@@ -68,9 +68,8 @@ NS_ASSUME_NONNULL_BEGIN
  Get oauth provider user profiles, the result dictionary key is provider id and value is profile
  dictionary.
 */
-- (void)getOAuthProviderProfiles:(NSString *)providerID
-               completionHandler:(void (^_Nullable)(NSDictionary *_Nullable,
-                                                    NSError *_Nullable))completionHandler;
+- (void)getOAuthProviderProfilesWithCompletionHandler:
+    (void (^_Nullable)(NSDictionary *_Nullable, NSError *_Nullable))completionHandler;
 
 /**
  Login the user with a custom token.

--- a/Pod/Extensions/SSO/SKYAuthContainer+SSO.m
+++ b/Pod/Extensions/SSO/SKYAuthContainer+SSO.m
@@ -102,9 +102,8 @@ typedef enum : NSInteger { SKYOAuthActionLogin, SKYOAuthActionLink } SKYOAuthAct
              }];
 }
 
-- (void)getOAuthProviderProfiles:(NSString *)providerID
-               completionHandler:
-                   (void (^)(NSDictionary *_Nullable, NSError *_Nullable))completionHandler
+- (void)getOAuthProviderProfilesWithCompletionHandler:
+    (void (^)(NSDictionary *_Nullable, NSError *_Nullable))completionHandler
 {
     [self.container callLambda:@"sso/provider_profiles" completionHandler:completionHandler];
 }

--- a/Pod/Extensions/SSO/SKYAuthContainer+SSO.m
+++ b/Pod/Extensions/SSO/SKYAuthContainer+SSO.m
@@ -223,8 +223,7 @@ typedef enum : NSInteger { SKYOAuthActionLogin, SKYOAuthActionLink } SKYOAuthAct
 
 - (NSURL *)sso_genCallbackURL:(NSString *)scheme
 {
-    NSString *host = self.container.endPointAddress.host;
-    return [[NSURL alloc] initWithScheme:scheme host:host path:@"/auth_handler"];
+    return [[NSURL alloc] initWithScheme:scheme host:@"skygeario.com" path:@"/auth_handler"];
 }
 
 #pragma mark - Custom Token


### PR DESCRIPTION
- Remove provider id from `getOAuthProviderProfiles` api which is not needed
- To make the configuration easier, fixed the callback url to `${APP_SCHEME}://skygeario.com/auth_handler` instead of using skygear server endpoint domain