### PR TITLE
Improve auth container response handling

### DIFF
--- a/Pod/Classes/SKYAuthContainer.h
+++ b/Pod/Classes/SKYAuthContainer.h
@@ -20,6 +20,7 @@
 #import <Foundation/Foundation.h>
 
 #import "SKYAccessToken.h"
+#import "SKYAuthResponseDelegateProtocol.h"
 #import "SKYDatabase.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -32,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 typedef void (^SKYContainerUserOperationActionCompletion)(SKYRecord *_Nullable user,
                                                           NSError *_Nullable error);
 
-@interface SKYAuthContainer : NSObject
+@interface SKYAuthContainer : NSObject <SKYAuthResponseDelegateProtocol>
 
 /// Undocumented
 @property (nonatomic, readonly) NSString *_Nullable currentUserRecordID;

--- a/Pod/Classes/SKYAuthOperation.h
+++ b/Pod/Classes/SKYAuthOperation.h
@@ -1,0 +1,30 @@
+//
+//  SKYAuthOperation.h
+//  SKYKit
+//
+//  Copyright 2018 Oursky Ltd.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "SKYAuthResponseDelegateProtocol.h"
+#import "SKYOperation.h"
+
+@interface SKYAuthOperation : SKYOperation
+
+/// Undocumented
+@property (nonatomic, readwrite, weak) id<SKYAuthResponseDelegateProtocol> authResponseDelegate;
+
+@end

--- a/Pod/Classes/SKYAuthOperation.m
+++ b/Pod/Classes/SKYAuthOperation.m
@@ -1,0 +1,64 @@
+//
+//  SKYAuthOperation.m
+//  SKYKit
+//
+//  Copyright 2018 Oursky Ltd.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "SKYAuthOperation.h"
+
+#import "SKYAuthOperation_Private.h"
+#import "SKYRecordDeserializer.h"
+#import "SKYResponse.h"
+
+@implementation SKYAuthOperation
+
+- (void)handleResponse:(SKYResponse *)aResponse
+{
+    SKYRecord *user = nil;
+    SKYAccessToken *accessToken = nil;
+    NSError *error = nil;
+
+    NSDictionary *response = aResponse.responseDictionary[@"result"];
+
+    if (self.authResponseDelegate) {
+        [self.authResponseDelegate operation:self didCompleteWithAuthResponse:response];
+    }
+
+    NSDictionary *profile = response[@"profile"];
+    NSString *recordID = profile[@"_id"];
+    if ([recordID hasPrefix:@"user/"] && response[@"access_token"]) {
+        user = [[SKYRecordDeserializer deserializer] recordWithDictionary:profile];
+        accessToken = [[SKYAccessToken alloc] initWithTokenString:response[@"access_token"]];
+    } else {
+        error = [self.errorCreator errorWithCode:SKYErrorBadResponse
+                                         message:@"Returned data does not contain expected data."];
+    }
+
+    if (!error) {
+        NSLog(@"User logged in with UserRecordID %@.", user.recordID.recordName);
+    }
+
+    [self handleAuthResponseWithUser:user accessToken:accessToken error:error];
+}
+
+- (void)handleAuthResponseWithUser:(SKYRecord *)record
+                       accessToken:(SKYAccessToken *)accessToken
+                             error:(NSError *)error
+{
+    // Should be overridden by subclasses
+}
+
+@end

--- a/Pod/Classes/SKYAuthOperation_Private.h
+++ b/Pod/Classes/SKYAuthOperation_Private.h
@@ -1,0 +1,37 @@
+//
+//  SKYAuthOperation.h
+//  SKYKit
+//
+//  Copyright 2018 Oursky Ltd.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "SKYAccessToken.h"
+#import "SKYOperationSubclass.h"
+#import "SKYOperation_Private.h"
+#import "SKYRecord.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SKYAuthOperation ()
+
+- (void)handleAuthResponseWithUser:(SKYRecord *)user
+                       accessToken:(SKYAccessToken *)accessToken
+                             error:(NSError *)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Pod/Classes/SKYAuthResponseDelegateProtocol.h
+++ b/Pod/Classes/SKYAuthResponseDelegateProtocol.h
@@ -1,0 +1,35 @@
+//
+//  SKYAuthResponseDelegateProtocol.h
+//  SKYKit
+//
+//  Copyright 2015 Oursky Ltd.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+@class SKYOperation;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Undocumented
+@protocol SKYAuthResponseDelegateProtocol
+
+@required
+
+/// Undocumented
+- (void)operation:(SKYOperation *)operation
+    didCompleteWithAuthResponse:(NSDictionary<NSString *, id> *)authResponse;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Pod/Classes/SKYChangePasswordOperation.h
+++ b/Pod/Classes/SKYChangePasswordOperation.h
@@ -19,12 +19,14 @@
 
 #import "SKYOperation.h"
 
+#import "SKYAuthOperation.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 @class SKYAccessToken;
 
 /// Undocumented
-@interface SKYChangePasswordOperation : SKYOperation
+@interface SKYChangePasswordOperation : SKYAuthOperation
 
 /// Undocumented
 @property (nonatomic, readonly, copy) NSString *oldPassword;

--- a/Pod/Classes/SKYChangePasswordOperation.m
+++ b/Pod/Classes/SKYChangePasswordOperation.m
@@ -19,8 +19,7 @@
 
 #import "SKYChangePasswordOperation.h"
 
-#import "SKYOperationSubclass.h"
-#import "SKYOperation_Private.h"
+#import "SKYAuthOperation_Private.h"
 #import "SKYRecordDeserializer.h"
 
 @implementation SKYChangePasswordOperation
@@ -67,23 +66,10 @@
     }
 }
 
-- (void)handleResponse:(SKYResponse *)aResponse
+- (void)handleAuthResponseWithUser:(SKYRecord *)user
+                       accessToken:(SKYAccessToken *)accessToken
+                             error:(NSError *)error
 {
-    SKYRecord *user = nil;
-    SKYAccessToken *accessToken = nil;
-    NSError *error = nil;
-
-    NSDictionary *response = aResponse.responseDictionary[@"result"];
-    NSDictionary *profile = response[@"profile"];
-    NSString *recordID = profile[@"_id"];
-    if ([recordID hasPrefix:@"user/"] && response[@"access_token"]) {
-        SKYRecordDeserializer *deserializer = [SKYRecordDeserializer deserializer];
-        user = [deserializer recordWithDictionary:profile];
-        accessToken = [[SKYAccessToken alloc] initWithTokenString:response[@"access_token"]];
-    } else {
-        error = [self.errorCreator errorWithResponseDictionary:response];
-    }
-
     if (self.changePasswordCompletionBlock) {
         self.changePasswordCompletionBlock(user, accessToken, error);
     }

--- a/Pod/Classes/SKYGetCurrentUserOperation.h
+++ b/Pod/Classes/SKYGetCurrentUserOperation.h
@@ -19,6 +19,8 @@
 
 #import "SKYOperation.h"
 
+#import "SKYAuthOperation.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 /// Undocumented
@@ -29,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * <SKYGetCurrentUserOperation> is a <SKYOperation> for getting current user from server
  */
-@interface SKYGetCurrentUserOperation : SKYOperation
+@interface SKYGetCurrentUserOperation : SKYAuthOperation
 
 /**
  *  Completiong Block of the Get Current User Operation

--- a/Pod/Classes/SKYGetCurrentUserOperation.m
+++ b/Pod/Classes/SKYGetCurrentUserOperation.m
@@ -18,7 +18,7 @@
 //
 
 #import "SKYGetCurrentUserOperation.h"
-#import "SKYOperationSubclass.h"
+#import "SKYAuthOperation_Private.h"
 #import "SKYRecordDeserializer.h"
 
 @interface SKYGetCurrentUserOperation ()
@@ -45,28 +45,10 @@
     self.request.accessToken = self.container.auth.currentAccessToken;
 }
 
-- (void)handleResponse:(SKYResponse *)response
+- (void)handleAuthResponseWithUser:(SKYRecord *)user
+                       accessToken:(SKYAccessToken *)accessToken
+                             error:(NSError *)error
 {
-    NSDictionary *responseDictionary = response.responseDictionary;
-    SKYRecord *user = nil;
-    SKYAccessToken *accessToken = nil;
-    NSError *error = nil;
-
-    if ([responseDictionary[@"result"] isKindOfClass:[NSDictionary class]]) {
-        NSDictionary *resultDictionary = responseDictionary[@"result"];
-        NSDictionary *profile = resultDictionary[@"profile"];
-        NSString *recordID = profile[@"_id"];
-        if ([recordID hasPrefix:@"user/"] && resultDictionary[@"access_token"]) {
-            accessToken =
-                [[SKYAccessToken alloc] initWithTokenString:resultDictionary[@"access_token"]];
-
-            user = [self.recordDeserializer recordWithDictionary:profile];
-        } else {
-            error = [self.errorCreator errorWithCode:SKYErrorBadResponse
-                                             message:@"A non-user record is received."];
-        }
-    }
-
     if (self.getCurrentUserCompletionBlock) {
         self.getCurrentUserCompletionBlock(user, accessToken, error);
     }

--- a/Pod/Classes/SKYKit.h
+++ b/Pod/Classes/SKYKit.h
@@ -24,6 +24,8 @@
 #import "SKYAsset.h"
 #import "SKYAssignUserRoleOperation.h"
 #import "SKYAuthContainer.h"
+#import "SKYAuthOperation.h"
+#import "SKYAuthResponseDelegateProtocol.h"
 #import "SKYChangePasswordOperation.h"
 #import "SKYContainer.h"
 #import "SKYDataSerialization.h"

--- a/Pod/Classes/SKYLoginUserOperation.h
+++ b/Pod/Classes/SKYLoginUserOperation.h
@@ -17,14 +17,15 @@
 //  limitations under the License.
 //
 
-#import "SKYOperation.h"
+#import "SKYAuthOperation.h"
 
 #import "SKYAccessToken.h"
+#import "SKYAuthResponseDelegateProtocol.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 /// Undocumented
-@interface SKYLoginUserOperation : SKYOperation
+@interface SKYLoginUserOperation : SKYAuthOperation
 
 /// Undocumented
 @property (nonatomic, readonly, copy) NSDictionary *_Nullable authData;

--- a/Pod/Classes/SKYLoginUserOperation.m
+++ b/Pod/Classes/SKYLoginUserOperation.m
@@ -18,9 +18,7 @@
 //
 
 #import "SKYLoginUserOperation.h"
-#import "SKYOperationSubclass.h"
-#import "SKYOperation_Private.h"
-#import "SKYRecordDeserializer.h"
+#import "SKYAuthOperation_Private.h"
 #import "SKYRequest.h"
 
 @implementation SKYLoginUserOperation {
@@ -96,29 +94,12 @@
     }
 }
 
-- (void)handleResponse:(SKYResponse *)aResponse
+- (void)handleAuthResponseWithUser:(SKYRecord *)record
+                       accessToken:(SKYAccessToken *)accessToken
+                             error:(NSError *)error
 {
-    SKYRecord *user = nil;
-    SKYAccessToken *accessToken = nil;
-    NSError *error = nil;
-
-    NSDictionary *response = aResponse.responseDictionary[@"result"];
-    NSDictionary *profile = response[@"profile"];
-    NSString *recordID = profile[@"_id"];
-    if ([recordID hasPrefix:@"user/"] && response[@"access_token"]) {
-        user = [[SKYRecordDeserializer deserializer] recordWithDictionary:profile];
-        accessToken = [[SKYAccessToken alloc] initWithTokenString:response[@"access_token"]];
-    } else {
-        error = [self.errorCreator errorWithCode:SKYErrorBadResponse
-                                         message:@"Returned data does not contain expected data."];
-    }
-
-    if (!error) {
-        NSLog(@"User logged in with UserRecordID %@.", user.recordID.recordName);
-    }
-
     if (self.loginCompletionBlock) {
-        self.loginCompletionBlock(user, accessToken, error);
+        self.loginCompletionBlock(record, accessToken, error);
     }
 }
 

--- a/Pod/Classes/SKYSignupUserOperation.h
+++ b/Pod/Classes/SKYSignupUserOperation.h
@@ -17,7 +17,7 @@
 //  limitations under the License.
 //
 
-#import "SKYOperation.h"
+#import "SKYAuthOperation.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
  If you assign a block to `signupCompletionBlock`, it will be called when
  the operation is completed.
  */
-@interface SKYSignupUserOperation : SKYOperation
+@interface SKYSignupUserOperation : SKYAuthOperation
 
 /**
  Auth data of the user. The Auth data is a unique dictionary across the system.

--- a/Pod/Classes/SKYSignupUserOperation.m
+++ b/Pod/Classes/SKYSignupUserOperation.m
@@ -18,8 +18,8 @@
 //
 
 #import "SKYSignupUserOperation.h"
+#import "SKYAuthOperation_Private.h"
 #import "SKYDataSerialization.h"
-#import "SKYOperation_Private.h"
 #import "SKYRecordDeserializer.h"
 #import "SKYRequest.h"
 
@@ -113,32 +113,19 @@
     }
 }
 
-- (void)setSignupCompletionBlock:(void (^)(SKYRecord *, SKYAccessToken *,
-                                           NSError *))signupCompletionBlock
+- (void)handleRequestError:(NSError *)error
 {
-    if (signupCompletionBlock) {
-        __weak typeof(self) weakSelf = self;
-        self.completionBlock = ^{
-            if (!weakSelf.error) {
-                NSDictionary *response = weakSelf.response[@"result"];
-                NSDictionary *profile = response[@"profile"];
+    if (self.signupCompletionBlock) {
+        self.signupCompletionBlock(nil, nil, error);
+    }
+}
 
-                SKYRecord *user =
-                    [[SKYRecordDeserializer deserializer] recordWithDictionary:profile];
-
-                SKYAccessToken *accessToken =
-                    [[SKYAccessToken alloc] initWithTokenString:response[@"access_token"]];
-
-                NSLog(@"User created with UserRecordID %@ and AccessToken %@", response[@"user_id"],
-                      response[@"access_token"]);
-
-                signupCompletionBlock(user, accessToken, nil);
-            } else {
-                signupCompletionBlock(nil, nil, weakSelf.error);
-            }
-        };
-    } else {
-        self.completionBlock = nil;
+- (void)handleAuthResponseWithUser:(SKYRecord *)user
+                       accessToken:(SKYAccessToken *)accessToken
+                             error:(NSError *)error
+{
+    if (self.signupCompletionBlock) {
+        self.signupCompletionBlock(user, accessToken, error);
     }
 }
 


### PR DESCRIPTION
This changeset modifies the way auth response is handled. SKYAuthOperation
is added and it should be subclassed by all operations that handle auth
response. Upon completing the operation, the operation calls the auth response
delegate, which is implemented by SKYAuthContainer. The SKYAuthContainer
is then responsible to update current user record and access token.

This allows the auth container to have access to the auth response, which
will have additional information not otherwise exposed by auth-related
operations.