### PR TITLE
Return error if API endpoint is not configured

### DIFF
--- a/Example/SKYKit.xcodeproj/project.pbxproj
+++ b/Example/SKYKit.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		F4BACC8B20221D79003E2FAA /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = F4BACC8920221D79003E2FAA /* MainMenu.xib */; };
 		F4BACC8E20221D79003E2FAA /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = F4BACC8D20221D79003E2FAA /* main.m */; };
 		F4E355DC20343B120053E0A9 /* SKYSetDisableUserOperationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F4E355DB20343B120053E0A9 /* SKYSetDisableUserOperationTests.m */; };
+		F4E553262074DE1D000E854A /* SKYContainer+Test.m in Sources */ = {isa = PBXBuildFile; fileRef = F4E553252074DE1D000E854A /* SKYContainer+Test.m */; };
 		F72C1CD25FC5E7B211DE7002 /* libPods-Mac Example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F9CFCD1EE493CB3F6B12642B /* libPods-Mac Example.a */; };
 /* End PBXBuildFile section */
 
@@ -250,6 +251,8 @@
 		F4BACC8D20221D79003E2FAA /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		F4BACC8F20221D79003E2FAA /* Mac_Example.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Mac_Example.entitlements; sourceTree = "<group>"; };
 		F4E355DB20343B120053E0A9 /* SKYSetDisableUserOperationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SKYSetDisableUserOperationTests.m; sourceTree = "<group>"; };
+		F4E553242074DE1D000E854A /* SKYContainer+Test.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SKYContainer+Test.h"; sourceTree = "<group>"; };
+		F4E553252074DE1D000E854A /* SKYContainer+Test.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "SKYContainer+Test.m"; sourceTree = "<group>"; };
 		F9CFCD1EE493CB3F6B12642B /* libPods-Mac Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Mac Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -469,6 +472,8 @@
 				37CDD6031B4BF1F8007B9FE1 /* SKYUploadAssetOperationTests.m */,
 				37F26A081AF8E91E006A21A8 /* Commons */,
 				6003F5B6195388D20070C39A /* Supporting Files */,
+				F4E553242074DE1D000E854A /* SKYContainer+Test.h */,
+				F4E553252074DE1D000E854A /* SKYContainer+Test.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -1032,6 +1037,7 @@
 				38EAA71B1B84937C009D25C1 /* SKYLocationSortDescriptorTests.m in Sources */,
 				F43CFB71205FBAF10059510C /* SKYAuthContainerForgotPasswordTests.m in Sources */,
 				CD395D0D1AA0273F00A97B16 /* SKYDatabaseTest.m in Sources */,
+				F4E553262074DE1D000E854A /* SKYContainer+Test.m in Sources */,
 				38D3E2341B7EDFD300CCD28D /* SKYSendPushNotificationOperationTests.m in Sources */,
 				F43389E01FE280BF00B7B317 /* SKYLoginCustomTokenOperationTests.m in Sources */,
 				3745755A1B08C682004539C3 /* SKYDeleteSubscriptionsOperationTests.m in Sources */,

--- a/Example/Tests/SKYAddRelationsOperationTests.m
+++ b/Example/Tests/SKYAddRelationsOperationTests.m
@@ -47,7 +47,7 @@ SpecBegin(SKYAddRelationsOperation)
                 [SKYAddRelationsOperation operationWithType:@"follow"
                                              usersToRelated:@[ follower1, follower2 ]];
             operation.container = container;
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
             SKYRequest *request = operation.request;
             expect([request class]).to.beSubclassOf([SKYRequest class]);
             expect(request.action).to.equal(@"relation:add");

--- a/Example/Tests/SKYAddRelationsOperationTests.m
+++ b/Example/Tests/SKYAddRelationsOperationTests.m
@@ -30,7 +30,7 @@ SpecBegin(SKYAddRelationsOperation)
         __block SKYContainer *container = nil;
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
+            container = [SKYContainer testContainer];
             [container.auth updateWithUserRecordID:@"USER_ID"
                                        accessToken:[[SKYAccessToken alloc]
                                                        initWithTokenString:@"ACCESS_TOKEN"]];

--- a/Example/Tests/SKYAssignUserRoleOperationTests.m
+++ b/Example/Tests/SKYAssignUserRoleOperationTests.m
@@ -49,7 +49,7 @@ SpecBegin(SKYAssignUserRoleOperation)
                            roleNames:@[ developerRoleName, testerRoleName ]];
 
             [operation setContainer:container];
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
 
             SKYRequest *request = operation.request;
             expect(request.action).to.equal(@"role:assign");

--- a/Example/Tests/SKYAssignUserRoleOperationTests.m
+++ b/Example/Tests/SKYAssignUserRoleOperationTests.m
@@ -37,8 +37,7 @@ SpecBegin(SKYAssignUserRoleOperation)
         __block SKYContainer *container;
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
-            [container configureWithAPIKey:apiKey];
+            container = [SKYContainer testContainer];
             [container.auth
                 updateWithUserRecordID:currentUserID
                            accessToken:[[SKYAccessToken alloc] initWithTokenString:token]];

--- a/Example/Tests/SKYAuthContainerTests.m
+++ b/Example/Tests/SKYAuthContainerTests.m
@@ -71,9 +71,8 @@ SpecBegin(SKYAuthContainer)
             };
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
+            container = [SKYContainer testContainer];
             container.defaultTimeoutInterval = 1.0;
-            [container configureWithAPIKey:@"API_KEY"];
             [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
                 NSString *path = [[request URL] path];
                 return
@@ -100,7 +99,7 @@ SpecBegin(SKYAuthContainer)
                         [OHHTTPStubsResponse responseWithData:payload statusCode:200 headers:@{}];
                 }];
 
-            SKYDatabase *database = [[SKYContainer defaultContainer] publicCloudDatabase];
+            SKYDatabase *database = [[SKYContainer testContainer] publicCloudDatabase];
             [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
                 return [[[request URL] path] isEqualToString:@"/record/save"];
             }
@@ -204,8 +203,7 @@ describe(@"get current user from server", ^{
     __block SKYContainer *container = nil;
 
     beforeEach(^{
-        container = [[SKYContainer alloc] init];
-        [container configureWithAPIKey:@"Correct API Key"];
+        container = [SKYContainer testContainer];
     });
 
     it(@"can handle success response", ^{
@@ -282,7 +280,7 @@ describe(@"get current user from server", ^{
 
 describe(@"save current user", ^{
     it(@"logout user", ^{
-        SKYContainer *container = [[SKYContainer alloc] init];
+        SKYContainer *container = [SKYContainer testContainer];
 
         [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
             return YES;
@@ -303,45 +301,46 @@ describe(@"save current user", ^{
     });
 
     it(@"fetch user with ID", ^{
-        SKYContainer *container = [[SKYContainer alloc] init];
+        SKYContainer *container = [SKYContainer testContainer];
         [container.auth
             updateWithUserRecordID:@"user1"
                        accessToken:[[SKYAccessToken alloc] initWithTokenString:@"accesstoken1"]];
 
-        container = [[SKYContainer alloc] init];
+        container = [SKYContainer testContainer];
         expect(container.auth.currentUserRecordID).to.equal(@"user1");
         expect(container.auth.currentAccessToken.tokenString).to.equal(@"accesstoken1");
     });
 
     it(@"fetch user with User", ^{
-        SKYContainer *container = [[SKYContainer alloc] init];
+        SKYContainer *container = [SKYContainer testContainer];
         SKYRecord *user = [SKYRecord recordWithRecordType:@"user" name:@"user1"];
         user[@"username"] = @"username1";
         [container.auth
             updateWithUser:user
                accessToken:[[SKYAccessToken alloc] initWithTokenString:@"accesstoken1"]];
 
-        container = [[SKYContainer alloc] init];
+        container = [SKYContainer testContainer];
         expect(container.auth.currentUserRecordID).to.equal(@"user1");
         expect(container.auth.currentUser[@"username"]).to.equal(@"username1");
         expect(container.auth.currentAccessToken.tokenString).to.equal(@"accesstoken1");
     });
 
     it(@"update with nil ID", ^{
-        SKYContainer *container = [[SKYContainer alloc] init];
+        SKYContainer *container = [SKYContainer testContainer];
         [container.auth updateWithUserRecordID:nil accessToken:nil];
 
-        container = [[SKYContainer alloc] init];
+        container = [SKYContainer testContainer];
         expect(container.auth.currentUserRecordID).to.beNil();
         expect(container.auth.currentUser).to.beNil();
         expect(container.auth.currentAccessToken).to.beNil();
     });
 
     it(@"update with nil User", ^{
-        SKYContainer *container = [[SKYContainer alloc] init];
+        SKYContainer *container = [SKYContainer testContainer];
+        [container configAddress:@"http://localhost/"];
         [container.auth updateWithUser:nil accessToken:nil];
 
-        container = [[SKYContainer alloc] init];
+        container = [SKYContainer testContainer];
         expect(container.auth.currentUserRecordID).to.beNil();
         expect(container.auth.currentUser).to.beNil();
         expect(container.auth.currentAccessToken).to.beNil();
@@ -359,7 +358,7 @@ describe(@"AuthenticationError callback", ^{
     __block SKYContainer *container = nil;
 
     beforeEach(^{
-        container = [[SKYContainer alloc] init];
+        container = [SKYContainer testContainer];
     });
 
     it(@"calls authentication error handler", ^{

--- a/Example/Tests/SKYChangePasswordOperationTests.m
+++ b/Example/Tests/SKYChangePasswordOperationTests.m
@@ -38,7 +38,7 @@ SpecBegin(SKYChangePasswordOperation)
                                                        passwordToSet:@"new_password"];
 
             operation.container = container;
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
 
             SKYRequest *request = operation.request;
             expect(request.action).to.equal(@"auth:password");

--- a/Example/Tests/SKYChangePasswordOperationTests.m
+++ b/Example/Tests/SKYChangePasswordOperationTests.m
@@ -26,8 +26,7 @@ SpecBegin(SKYChangePasswordOperation)
         __block SKYContainer *container = nil;
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
-            [container configureWithAPIKey:@"API_KEY"];
+            container = [SKYContainer testContainer];
             [container.auth updateWithUserRecordID:@"USER_ID"
                                        accessToken:[[SKYAccessToken alloc]
                                                        initWithTokenString:@"ACCESS_TOKEN"]];

--- a/Example/Tests/SKYContainer+Test.h
+++ b/Example/Tests/SKYContainer+Test.h
@@ -1,0 +1,27 @@
+//
+//  SKYContainer+Test.h
+//  SKYKit
+//
+//  Copyright 2015 Oursky Ltd.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "SKYContainer.h"
+#import <Foundation/Foundation.h>
+
+@interface SKYContainer (Test)
+
++ (SKYContainer *_Nonnull)testContainer;
+
+@end

--- a/Example/Tests/SKYContainer+Test.m
+++ b/Example/Tests/SKYContainer+Test.m
@@ -1,0 +1,32 @@
+//
+//  SKYContainer+Test.m
+//  SKYKit
+//
+//  Copyright 2015 Oursky Ltd.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "SKYContainer+Test.h"
+
+@implementation SKYContainer (Test)
+
++ (SKYContainer *)testContainer
+{
+    SKYContainer *container = [[SKYContainer alloc] init];
+    [container configAddress:@"http://skygear.localhost"];
+    [container configureWithAPIKey:@"API_KEY"];
+    return container;
+}
+
+@end

--- a/Example/Tests/SKYContainer+Test.m
+++ b/Example/Tests/SKYContainer+Test.m
@@ -24,6 +24,7 @@
 + (SKYContainer *)testContainer
 {
     SKYContainer *container = [[SKYContainer alloc] init];
+    container.pubsub.autoInternalPubsub = NO;
     [container configAddress:@"http://skygear.localhost"];
     [container configureWithAPIKey:@"API_KEY"];
     return container;

--- a/Example/Tests/SKYContainerTests.m
+++ b/Example/Tests/SKYContainerTests.m
@@ -37,7 +37,7 @@ SpecBegin(SKYContainer)
             [container configAddress:@"http://newpoint.com:4321/"];
             NSURL *expectEndPoint = [NSURL URLWithString:@"http://newpoint.com:4321/"];
             expect(container.endPointAddress).to.equal(expectEndPoint);
-            expect(container.pubsub.endPointAddress)
+            expect(container.pubsub.pubsubClient.endPointAddress)
                 .to.equal([NSURL URLWithString:@"ws://newpoint.com:4321/pubsub"]);
         });
     });

--- a/Example/Tests/SKYContainerTests.m
+++ b/Example/Tests/SKYContainerTests.m
@@ -33,7 +33,7 @@ SpecBegin(SKYContainer)
 
     describe(@"config End Point address", ^{
         it(@"set the endPointAddress correctly", ^{
-            SKYContainer *container = [[SKYContainer alloc] init];
+            SKYContainer *container = [SKYContainer testContainer];
             [container configAddress:@"http://newpoint.com:4321/"];
             NSURL *expectEndPoint = [NSURL URLWithString:@"http://newpoint.com:4321/"];
             expect(container.endPointAddress).to.equal(expectEndPoint);
@@ -44,7 +44,7 @@ SpecBegin(SKYContainer)
 
 describe(@"Default container", ^{
     it(@"give DB default ID", ^{
-        SKYContainer *container = [[SKYContainer alloc] init];
+        SKYContainer *container = [SKYContainer testContainer];
         expect(container.publicCloudDatabase.databaseID).to.equal(@"_public");
         expect(container.privateCloudDatabase.databaseID).to.equal(@"_private");
     });
@@ -52,7 +52,7 @@ describe(@"Default container", ^{
 
 describe(@"calls lambda", ^{
     it(@"calls lambda no arguments", ^{
-        SKYContainer *container = [[SKYContainer alloc] init];
+        SKYContainer *container = [SKYContainer testContainer];
 
         [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
             return YES;
@@ -76,7 +76,7 @@ describe(@"calls lambda", ^{
     });
 
     it(@"calls lambda with arguments", ^{
-        SKYContainer *container = [[SKYContainer alloc] init];
+        SKYContainer *container = [SKYContainer testContainer];
 
         [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
             return YES;
@@ -110,7 +110,7 @@ describe(@"calls lambda", ^{
     });
 
     it(@"calls lambda with array arguments", ^{
-        SKYContainer *container = [[SKYContainer alloc] init];
+        SKYContainer *container = [SKYContainer testContainer];
         [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
             return YES;
         }
@@ -142,7 +142,7 @@ describe(@"calls lambda", ^{
     });
 
     it(@"calls lambda with dictionary arguments", ^{
-        SKYContainer *container = [[SKYContainer alloc] init];
+        SKYContainer *container = [SKYContainer testContainer];
         [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
             return YES;
         }
@@ -192,8 +192,7 @@ describe(@"manage roles", ^{
     __block SKYContainer *container = nil;
 
     beforeEach(^{
-        container = [[SKYContainer alloc] init];
-        [container configureWithAPIKey:apiKey];
+        container = [SKYContainer testContainer];
         [container.auth updateWithUserRecordID:currentUserId
                                    accessToken:[[SKYAccessToken alloc] initWithTokenString:token]];
     });
@@ -266,8 +265,7 @@ describe(@"record creation access", ^{
     __block SKYContainer *container = nil;
 
     beforeEach(^{
-        container = [[SKYContainer alloc] init];
-        [container configureWithAPIKey:apiKey];
+        container = [SKYContainer testContainer];
         [container.auth updateWithUserRecordID:currentUserId
                                    accessToken:[[SKYAccessToken alloc] initWithTokenString:token]];
     });
@@ -313,8 +311,7 @@ describe(@"record default access", ^{
     __block SKYContainer *container = nil;
 
     beforeEach(^{
-        container = [[SKYContainer alloc] init];
-        [container configureWithAPIKey:apiKey];
+        container = [SKYContainer testContainer];
         [container.auth updateWithUserRecordID:currentUserId
                                    accessToken:[[SKYAccessToken alloc] initWithTokenString:token]];
     });

--- a/Example/Tests/SKYDatabaseTest.m
+++ b/Example/Tests/SKYDatabaseTest.m
@@ -24,8 +24,15 @@
 SpecBegin(SKYDatabase)
 
     describe(@"database", ^{
+        __block SKYContainer *container;
+        __block SKYDatabase *database;
+
+        beforeEach(^{
+            container = [SKYContainer testContainer];
+            database = [container publicCloudDatabase];
+        });
+
         it(@"fetch record", ^{
-            SKYDatabase *database = [[SKYContainer defaultContainer] publicCloudDatabase];
             NSString *bookTitle = @"A tale of two cities";
             [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
                 return YES;
@@ -65,7 +72,6 @@ SpecBegin(SKYDatabase)
         });
 
         it(@"fetch record with operation error", ^{
-            SKYDatabase *database = [[SKYContainer defaultContainer] publicCloudDatabase];
             [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
                 return YES;
             }
@@ -92,7 +98,6 @@ SpecBegin(SKYDatabase)
         });
 
         it(@"fetch records", ^{
-            SKYDatabase *database = [[SKYContainer defaultContainer] publicCloudDatabase];
             SKYRecordID *recordID1 = [[SKYRecordID alloc] initWithRecordType:@"book" name:@"book1"];
             SKYRecordID *recordID2 = [[SKYRecordID alloc] initWithRecordType:@"book" name:@"book2"];
             NSString *bookTitle = @"A tale of two cities";
@@ -146,7 +151,6 @@ SpecBegin(SKYDatabase)
         });
 
         it(@"modify record", ^{
-            SKYDatabase *database = [[SKYContainer defaultContainer] publicCloudDatabase];
             NSString *bookTitle = @"A tale of two cities";
             SKYRecord *record = [[SKYRecord alloc]
                 initWithRecordID:[[SKYRecordID alloc] initWithRecordType:@"book" name:@"book1"]
@@ -189,7 +193,6 @@ SpecBegin(SKYDatabase)
         });
 
         it(@"modify record with operation error", ^{
-            SKYDatabase *database = [[SKYContainer defaultContainer] publicCloudDatabase];
             NSString *bookTitle = @"A tale of two cities";
             SKYRecord *record = [[SKYRecord alloc]
                 initWithRecordID:[[SKYRecordID alloc] initWithRecordType:@"book" name:@"book1"]
@@ -220,7 +223,6 @@ SpecBegin(SKYDatabase)
         });
 
         it(@"modify records", ^{
-            SKYDatabase *database = [[SKYContainer defaultContainer] publicCloudDatabase];
             NSString *bookTitle = @"A tale of two cities";
             SKYRecord *record1 = [[SKYRecord alloc]
                 initWithRecordID:[[SKYRecordID alloc] initWithRecordType:@"book" name:@"book1"]
@@ -279,7 +281,6 @@ SpecBegin(SKYDatabase)
         });
 
         it(@"delete record", ^{
-            SKYDatabase *database = [[SKYContainer defaultContainer] publicCloudDatabase];
             SKYRecordID *recordID = [[SKYRecordID alloc] initWithRecordType:@"book" name:@"book1"];
 
             [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
@@ -312,7 +313,6 @@ SpecBegin(SKYDatabase)
         });
 
         it(@"delete record with operation error", ^{
-            SKYDatabase *database = [[SKYContainer defaultContainer] publicCloudDatabase];
             SKYRecordID *recordID = [[SKYRecordID alloc] initWithRecordType:@"book" name:@"book1"];
 
             [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
@@ -339,7 +339,6 @@ SpecBegin(SKYDatabase)
         });
 
         it(@"delete records", ^{
-            SKYDatabase *database = [[SKYContainer defaultContainer] publicCloudDatabase];
             SKYRecordID *recordID1 = [[SKYRecordID alloc] initWithRecordType:@"book" name:@"book1"];
             SKYRecordID *recordID2 = [[SKYRecordID alloc] initWithRecordType:@"book" name:@"book2"];
 
@@ -387,7 +386,6 @@ SpecBegin(SKYDatabase)
         });
 
         it(@"perform query", ^{
-            SKYDatabase *database = [[SKYContainer defaultContainer] publicCloudDatabase];
             [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
                 return YES;
             }
@@ -428,7 +426,6 @@ SpecBegin(SKYDatabase)
         });
 
         it(@"perform query with operation error", ^{
-            SKYDatabase *database = [[SKYContainer defaultContainer] publicCloudDatabase];
             [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
                 return YES;
             }
@@ -454,7 +451,6 @@ SpecBegin(SKYDatabase)
         });
 
         it(@"fetch all subscriptions", ^{
-            SKYDatabase *database = [[SKYContainer defaultContainer] publicCloudDatabase];
             [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
                 return YES;
             }

--- a/Example/Tests/SKYDefineAdminRolesOperationTests.m
+++ b/Example/Tests/SKYDefineAdminRolesOperationTests.m
@@ -50,7 +50,7 @@ SpecBegin(SKYDefineAdminRolesOperation)
                 [SKYDefineAdminRolesOperation operationWithRoles:roles];
 
             [operation setContainer:container];
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
 
             SKYRequest *request = operation.request;
             expect(request.action).to.equal(@"role:admin");

--- a/Example/Tests/SKYDefineAdminRolesOperationTests.m
+++ b/Example/Tests/SKYDefineAdminRolesOperationTests.m
@@ -39,8 +39,7 @@ SpecBegin(SKYDefineAdminRolesOperation)
         __block SKYContainer *container = nil;
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
-            [container configureWithAPIKey:apiKey];
+            container = [SKYContainer testContainer];
             [container.auth
                 updateWithUserRecordID:currentUserID
                            accessToken:[[SKYAccessToken alloc] initWithTokenString:token]];

--- a/Example/Tests/SKYDefineCreationAccessOperationTests.m
+++ b/Example/Tests/SKYDefineCreationAccessOperationTests.m
@@ -49,7 +49,7 @@ SpecBegin(SKYDefineCreationAccessOperation)
                 operationWithRecordType:sourceCodeRecordType
                                   roles:@[ developerRole, testerRole ]];
             [operation setContainer:container];
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
 
             SKYRequest *request = operation.request;
             expect(request.action).to.equal(@"schema:access");

--- a/Example/Tests/SKYDefineCreationAccessOperationTests.m
+++ b/Example/Tests/SKYDefineCreationAccessOperationTests.m
@@ -38,8 +38,7 @@ SpecBegin(SKYDefineCreationAccessOperation)
         __block SKYContainer *container;
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
-            [container configureWithAPIKey:apiKey];
+            container = [SKYContainer testContainer];
             [container.auth
                 updateWithUserRecordID:currentUserID
                            accessToken:[[SKYAccessToken alloc] initWithTokenString:token]];

--- a/Example/Tests/SKYDefineDefaultAccessOperationTests.m
+++ b/Example/Tests/SKYDefineDefaultAccessOperationTests.m
@@ -55,7 +55,7 @@ SpecBegin(SKYDefineDefaultAccessOperation)
                 [SKYDefineDefaultAccessOperation operationWithRecordType:sourceCodeRecordType
                                                            accessControl:acl];
             [operation setContainer:container];
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
 
             SKYRequest *request = operation.request;
             expect(request.action).to.equal(@"schema:default_access");

--- a/Example/Tests/SKYDefineDefaultAccessOperationTests.m
+++ b/Example/Tests/SKYDefineDefaultAccessOperationTests.m
@@ -44,8 +44,7 @@ SpecBegin(SKYDefineDefaultAccessOperation)
         __block SKYContainer *container;
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
-            [container configureWithAPIKey:apiKey];
+            container = [SKYContainer testContainer];
             [container.auth
                 updateWithUserRecordID:currentUserID
                            accessToken:[[SKYAccessToken alloc] initWithTokenString:token]];

--- a/Example/Tests/SKYDeleteRecordsOperationTests.m
+++ b/Example/Tests/SKYDeleteRecordsOperationTests.m
@@ -41,7 +41,7 @@ SpecBegin(SKYDeleteRecordsOperation)
                 [SKYDeleteRecordsOperation operationWithRecordIDsToDelete:@[ recordID ]];
             operation.database = database;
             operation.container = container;
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
             SKYRequest *request = operation.request;
             expect([request class]).to.beSubclassOf([SKYRequest class]);
             expect(request.action).to.equal(@"record:delete");
@@ -57,7 +57,7 @@ SpecBegin(SKYDeleteRecordsOperation)
                 operationWithRecordIDsToDelete:@[ recordID1, recordID2 ]];
             operation.database = database;
             operation.container = container;
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
             SKYRequest *request = operation.request;
             expect([request class]).to.beSubclassOf([SKYRequest class]);
             expect(request.action).to.equal(@"record:delete");
@@ -75,7 +75,7 @@ SpecBegin(SKYDeleteRecordsOperation)
 
             operation.database = database;
             operation.container = container;
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
 
             SKYRequest *request = operation.request;
             expect(request.payload[@"atomic"]).to.equal(@YES);

--- a/Example/Tests/SKYDeleteRecordsOperationTests.m
+++ b/Example/Tests/SKYDeleteRecordsOperationTests.m
@@ -28,7 +28,7 @@ SpecBegin(SKYDeleteRecordsOperation)
         __block SKYDatabase *database = nil;
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
+            container = [SKYContainer testContainer];
             [container.auth updateWithUserRecordID:@"USER_ID"
                                        accessToken:[[SKYAccessToken alloc]
                                                        initWithTokenString:@"ACCESS_TOKEN"]];

--- a/Example/Tests/SKYDeleteSubscriptionsOperationTests.m
+++ b/Example/Tests/SKYDeleteSubscriptionsOperationTests.m
@@ -41,7 +41,7 @@ SpecBegin(SKYDeleteSubscriptionsOperation)
                 subscriptionIDsToDelete:@[ @"my notes", @"ben's notes" ]];
             operation.database = database;
             operation.container = container;
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
             SKYRequest *request = operation.request;
             expect([request class]).to.beSubclassOf([SKYRequest class]);
             expect(request.action).to.equal(@"subscription:delete");

--- a/Example/Tests/SKYDeleteSubscriptionsOperationTests.m
+++ b/Example/Tests/SKYDeleteSubscriptionsOperationTests.m
@@ -28,8 +28,7 @@ SpecBegin(SKYDeleteSubscriptionsOperation)
         __block SKYDatabase *database = nil;
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
-            [container configureWithAPIKey:@"API_KEY"];
+            container = [SKYContainer testContainer];
             [container.auth updateWithUserRecordID:@"USER_ID"
                                        accessToken:[[SKYAccessToken alloc]
                                                        initWithTokenString:@"ACCESS_TOKEN"]];

--- a/Example/Tests/SKYDownloadAssetOperationTests.m
+++ b/Example/Tests/SKYDownloadAssetOperationTests.m
@@ -44,9 +44,7 @@ SpecBegin(SKYDownloadAssetOperation)
         __block SKYAsset *asset = nil;
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
-            [container configAddress:@"http://skygear.test/"];
-            [container configureWithAPIKey:@"API_KEY"];
+            container = [SKYContainer testContainer];
             [container.auth updateWithUserRecordID:@"USER_ID"
                                        accessToken:[[SKYAccessToken alloc]
                                                        initWithTokenString:@"ACCESS_TOKEN"]];

--- a/Example/Tests/SKYFetchRecordsOperationTests.m
+++ b/Example/Tests/SKYFetchRecordsOperationTests.m
@@ -28,8 +28,7 @@ SpecBegin(SKYFetchRecordsOperation)
         __block SKYDatabase *database = nil;
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
-            [container configureWithAPIKey:@"API_KEY"];
+            container = [SKYContainer testContainer];
             [container.auth updateWithUserRecordID:@"USER_ID"
                                        accessToken:[[SKYAccessToken alloc]
                                                        initWithTokenString:@"ACCESS_TOKEN"]];

--- a/Example/Tests/SKYFetchRecordsOperationTests.m
+++ b/Example/Tests/SKYFetchRecordsOperationTests.m
@@ -41,7 +41,7 @@ SpecBegin(SKYFetchRecordsOperation)
                 [SKYFetchRecordsOperation operationWithRecordIDs:@[ recordID ]];
             operation.container = container;
             operation.database = database;
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
             SKYRequest *request = operation.request;
             expect([request class]).to.beSubclassOf([SKYRequest class]);
             expect(request.action).to.equal(@"record:fetch");
@@ -59,7 +59,7 @@ SpecBegin(SKYFetchRecordsOperation)
                 [SKYFetchRecordsOperation operationWithRecordIDs:@[ recordID1, recordID2 ]];
             operation.container = container;
             operation.database = database;
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
             SKYRequest *request = operation.request;
             expect([request class]).to.beSubclassOf([SKYRequest class]);
             expect(request.action).to.equal(@"record:fetch");

--- a/Example/Tests/SKYFetchSubscriptionsOperationTests.m
+++ b/Example/Tests/SKYFetchSubscriptionsOperationTests.m
@@ -42,7 +42,7 @@ SpecBegin(SKYFetchSubscriptionsOperation)
             operation.container = container;
             operation.database = database;
 
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
 
             SKYRequest *request = operation.request;
             expect([request class]).to.beSubclassOf([SKYRequest class]);
@@ -64,7 +64,7 @@ SpecBegin(SKYFetchSubscriptionsOperation)
             operation.container = container;
             operation.database = database;
 
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
 
             SKYRequest *request = operation.request;
             expect([request class]).to.beSubclassOf([SKYRequest class]);

--- a/Example/Tests/SKYFetchSubscriptionsOperationTests.m
+++ b/Example/Tests/SKYFetchSubscriptionsOperationTests.m
@@ -28,8 +28,7 @@ SpecBegin(SKYFetchSubscriptionsOperation)
         __block SKYDatabase *database = nil;
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
-            [container configureWithAPIKey:@"API_KEY"];
+            container = [SKYContainer testContainer];
             [container.auth updateWithUserRecordID:@"USER_ID"
                                        accessToken:[[SKYAccessToken alloc]
                                                        initWithTokenString:@"ACCESS_TOKEN"]];

--- a/Example/Tests/SKYFetchUserRoleOperationTests.m
+++ b/Example/Tests/SKYFetchUserRoleOperationTests.m
@@ -45,7 +45,7 @@ SpecBegin(SKYFetchUserRoleOperation)
                 [SKYFetchUserRoleOperation operationWithUserIDs:@[ user1, user2, user3 ]];
 
             [operation setContainer:container];
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
 
             SKYRequest *request = operation.request;
             expect(request.action).to.equal(@"role:get");

--- a/Example/Tests/SKYFetchUserRoleOperationTests.m
+++ b/Example/Tests/SKYFetchUserRoleOperationTests.m
@@ -34,8 +34,7 @@ SpecBegin(SKYFetchUserRoleOperation)
         __block SKYContainer *container;
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
-            [container configureWithAPIKey:apiKey];
+            container = [SKYContainer testContainer];
             [container.auth
                 updateWithUserRecordID:currentUserID
                            accessToken:[[SKYAccessToken alloc] initWithTokenString:token]];

--- a/Example/Tests/SKYGetAssetPostRequestOperationTests.m
+++ b/Example/Tests/SKYGetAssetPostRequestOperationTests.m
@@ -50,7 +50,7 @@ SpecBegin(SKYGetAssetPostRequestOperation)
             SKYGetAssetPostRequestOperation *operation =
                 [SKYGetAssetPostRequestOperation operationWithAsset:asset];
             [operation setContainer:container];
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
 
             SKYRequest *request = operation.request;
             expect([request class]).to.beSubclassOf([SKYRequest class]);

--- a/Example/Tests/SKYGetAssetPostRequestOperationTests.m
+++ b/Example/Tests/SKYGetAssetPostRequestOperationTests.m
@@ -30,9 +30,7 @@ SpecBegin(SKYGetAssetPostRequestOperation)
         __block SKYAsset *asset;
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
-            [container configAddress:@"http://skygear.dev/"];
-            [container configureWithAPIKey:@"API-KEY"];
+            container = [SKYContainer testContainer];
             [container.auth updateWithUserRecordID:@"Test-User-ID"
                                        accessToken:[[SKYAccessToken alloc]
                                                        initWithTokenString:@"Test-Access-Token"]];
@@ -57,7 +55,7 @@ SpecBegin(SKYGetAssetPostRequestOperation)
             SKYRequest *request = operation.request;
             expect([request class]).to.beSubclassOf([SKYRequest class]);
             expect(request.action).to.equal(@"asset:put");
-            expect(request.APIKey).to.equal(@"API-KEY");
+            expect(request.APIKey).to.equal(@"API_KEY");
             expect(request.accessToken.tokenString).to.equal(@"Test-Access-Token");
             expect(request.payload).to.equal(@{
                 @"filename" : asset.name,

--- a/Example/Tests/SKYGetCurrentUserOperationTests.m
+++ b/Example/Tests/SKYGetCurrentUserOperationTests.m
@@ -27,7 +27,7 @@ SpecBegin(SKYGetCurrentUserOperation)
         __block SKYContainer *container = nil;
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
+            container = [SKYContainer testContainer];
             [container.auth
                 updateWithUserRecordID:@"user-1"
                            accessToken:[[SKYAccessToken alloc] initWithTokenString:@"token-1"]];

--- a/Example/Tests/SKYGetCurrentUserOperationTests.m
+++ b/Example/Tests/SKYGetCurrentUserOperationTests.m
@@ -40,7 +40,7 @@ SpecBegin(SKYGetCurrentUserOperation)
         it(@"should prepare correct SKYRequest", ^{
             SKYGetCurrentUserOperation *operation = [[SKYGetCurrentUserOperation alloc] init];
             [operation setContainer:container];
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
 
             SKYRequest *request = operation.request;
             expect([request class]).to.beSubclassOf([SKYRequest class]);

--- a/Example/Tests/SKYLambdaOperationTests.m
+++ b/Example/Tests/SKYLambdaOperationTests.m
@@ -38,7 +38,7 @@ SpecBegin(SKYLambdaOperation)
             SKYLambdaOperation *operation =
                 [SKYLambdaOperation operationWithAction:@"hello:world" arrayArguments:args];
             operation.container = container;
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
             SKYRequest *request = operation.request;
             expect([request class]).to.beSubclassOf([SKYRequest class]);
             expect(request.action).to.equal(@"hello:world");
@@ -52,7 +52,7 @@ SpecBegin(SKYLambdaOperation)
             SKYLambdaOperation *operation =
                 [SKYLambdaOperation operationWithAction:@"hello:world" dictionaryArguments:args];
             operation.container = container;
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
             SKYRequest *request = operation.request;
             expect([request class]).to.beSubclassOf([SKYRequest class]);
             expect(request.action).to.equal(@"hello:world");

--- a/Example/Tests/SKYLambdaOperationTests.m
+++ b/Example/Tests/SKYLambdaOperationTests.m
@@ -27,8 +27,7 @@ SpecBegin(SKYLambdaOperation)
         __block SKYContainer *container = nil;
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
-            [container configureWithAPIKey:@"API_KEY"];
+            container = [SKYContainer testContainer];
             [container.auth updateWithUserRecordID:@"USER_ID"
                                        accessToken:[[SKYAccessToken alloc]
                                                        initWithTokenString:@"ACCESS_TOKEN"]];

--- a/Example/Tests/SKYLoginUserOperationTests.m
+++ b/Example/Tests/SKYLoginUserOperationTests.m
@@ -27,8 +27,7 @@ SpecBegin(SKYLoginUserOperation)
         __block SKYContainer *container = nil;
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
-            [container configureWithAPIKey:@"API_KEY"];
+            container = [SKYContainer testContainer];
             [container.auth updateWithUserRecordID:@"USER_ID"
                                        accessToken:[[SKYAccessToken alloc]
                                                        initWithTokenString:@"ACCESS_TOKEN"]];

--- a/Example/Tests/SKYLoginUserOperationTests.m
+++ b/Example/Tests/SKYLoginUserOperationTests.m
@@ -38,7 +38,7 @@ SpecBegin(SKYLoginUserOperation)
                 [SKYLoginUserOperation operationWithAuthData:@{@"username" : @"username"}
                                                     password:@"password"];
             operation.container = container;
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
             SKYRequest *request = operation.request;
             expect([request class]).to.beSubclassOf([SKYRequest class]);
             expect(request.action).to.equal(@"auth:login");
@@ -53,7 +53,7 @@ SpecBegin(SKYLoginUserOperation)
                 [SKYLoginUserOperation operationWithAuthData:@{@"email" : @"user@example.com"}
                                                     password:@"password"];
             operation.container = container;
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
             SKYRequest *request = operation.request;
             expect([request class]).to.beSubclassOf([SKYRequest class]);
             expect(request.action).to.equal(@"auth:login");
@@ -70,7 +70,7 @@ SpecBegin(SKYLoginUserOperation)
                                                 @"access_token" : @"hello_world",
                                             }];
             operation.container = container;
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
             SKYRequest *request = operation.request;
             expect([request class]).to.beSubclassOf([SKYRequest class]);
             expect(request.action).to.equal(@"auth:login");

--- a/Example/Tests/SKYLogoutUserOperationTests.m
+++ b/Example/Tests/SKYLogoutUserOperationTests.m
@@ -36,7 +36,7 @@ SpecBegin(SKYLogoutUserOperation)
         it(@"make SKYRequest", ^{
             SKYLogoutUserOperation *operation = [[SKYLogoutUserOperation alloc] init];
             operation.container = container;
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
             SKYRequest *request = operation.request;
             expect([request class]).to.beSubclassOf([SKYRequest class]);
             expect(request.action).to.equal(@"auth:logout");

--- a/Example/Tests/SKYLogoutUserOperationTests.m
+++ b/Example/Tests/SKYLogoutUserOperationTests.m
@@ -27,7 +27,7 @@ SpecBegin(SKYLogoutUserOperation)
         __block SKYContainer *container = nil;
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
+            container = [SKYContainer testContainer];
             [container.auth updateWithUserRecordID:@"USER_ID"
                                        accessToken:[[SKYAccessToken alloc]
                                                        initWithTokenString:@"ACCESS_TOKEN"]];

--- a/Example/Tests/SKYModifyRecordsOperationTests.m
+++ b/Example/Tests/SKYModifyRecordsOperationTests.m
@@ -30,7 +30,7 @@ SpecBegin(SKYModifyRecordsOperation)
         __block SKYDatabase *database = nil;
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
+            container = [SKYContainer testContainer];
             [container.auth updateWithUserRecordID:@"USER_ID"
                                        accessToken:[[SKYAccessToken alloc]
                                                        initWithTokenString:@"ACCESS_TOKEN"]];

--- a/Example/Tests/SKYModifyRecordsOperationTests.m
+++ b/Example/Tests/SKYModifyRecordsOperationTests.m
@@ -48,7 +48,7 @@ SpecBegin(SKYModifyRecordsOperation)
                 [SKYModifyRecordsOperation operationWithRecordsToSave:@[ record1, record2 ]];
             operation.container = container;
             operation.database = database;
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
             SKYRequest *request = operation.request;
             expect([request class]).to.beSubclassOf([SKYRequest class]);
             expect(request.action).to.equal(@"record:save");
@@ -69,7 +69,7 @@ SpecBegin(SKYModifyRecordsOperation)
 
             operation.container = container;
             operation.database = database;
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
 
             SKYRequest *request = operation.request;
             expect(request.payload[@"atomic"]).to.equal(@YES);

--- a/Example/Tests/SKYModifySubscriptionsOperationTests.m
+++ b/Example/Tests/SKYModifySubscriptionsOperationTests.m
@@ -45,7 +45,7 @@ SpecBegin(SKYModifySubscriptionsOperation)
                   subscriptionsToSave:@[ subscription1, subscription2 ]];
             operation.container = container;
             operation.database = database;
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
             SKYRequest *request = operation.request;
             expect([request class]).to.beSubclassOf([SKYRequest class]);
             expect(request.action).to.equal(@"subscription:save");

--- a/Example/Tests/SKYModifySubscriptionsOperationTests.m
+++ b/Example/Tests/SKYModifySubscriptionsOperationTests.m
@@ -30,8 +30,7 @@ SpecBegin(SKYModifySubscriptionsOperation)
         __block SKYDatabase *database = nil;
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
-            [container configureWithAPIKey:@"API_KEY"];
+            container = [SKYContainer testContainer];
             [container.auth updateWithUserRecordID:@"USER_ID"
                                        accessToken:[[SKYAccessToken alloc]
                                                        initWithTokenString:@"ACCESS_TOKEN"]];

--- a/Example/Tests/SKYOperationTests.m
+++ b/Example/Tests/SKYOperationTests.m
@@ -275,19 +275,19 @@ SpecBegin(SKYOperation)
 
         it(@"error when container is not configured", ^{
             SKYContainer *container = [[SKYContainer alloc] init];
-            NSString *action = @"auth:login";
-            NSDictionary *payload = @{};
+            container.pubsub.autoInternalPubsub = NO;
 
-            SKYRequest *request = [[SKYRequest alloc] initWithAction:action payload:payload];
-            SKYOperation *operation = [[SKYOperation alloc] initWithRequest:request];
+            SKYLogoutUserOperation *operation = [[SKYLogoutUserOperation alloc] init];
 
             waitUntil(^(DoneCallback done) {
                 __block typeof(operation) blockOp = operation;
-                operation.completionBlock = ^{
+                operation.logoutCompletionBlock = ^(NSError *error) {
                     dispatch_async(dispatch_get_main_queue(), ^{
                         expect(blockOp.finished).to.equal(YES);
                         expect(blockOp.lastError).toNot.beNil();
                         expect(blockOp.lastError.code).to.equal(SKYErrorContainerNotConfigured);
+                        expect(error).toNot.beNil();
+                        expect(error.code).to.equal(SKYErrorContainerNotConfigured);
                         done();
                     });
                 };

--- a/Example/Tests/SKYOperationTests.m
+++ b/Example/Tests/SKYOperationTests.m
@@ -273,6 +273,28 @@ SpecBegin(SKYOperation)
             });
         });
 
+        it(@"error when container is not configured", ^{
+            SKYContainer *container = [[SKYContainer alloc] init];
+            NSString *action = @"auth:login";
+            NSDictionary *payload = @{};
+
+            SKYRequest *request = [[SKYRequest alloc] initWithAction:action payload:payload];
+            SKYOperation *operation = [[SKYOperation alloc] initWithRequest:request];
+
+            waitUntil(^(DoneCallback done) {
+                __block typeof(operation) blockOp = operation;
+                operation.completionBlock = ^{
+                    dispatch_async(dispatch_get_main_queue(), ^{
+                        expect(blockOp.finished).to.equal(YES);
+                        expect(blockOp.lastError).toNot.beNil();
+                        expect(blockOp.lastError.code).to.equal(SKYErrorContainerNotConfigured);
+                        done();
+                    });
+                };
+                [container addOperation:operation];
+            });
+        });
+
         afterEach(^{
             [OHHTTPStubs removeAllStubs];
         });

--- a/Example/Tests/SKYOperationTests.m
+++ b/Example/Tests/SKYOperationTests.m
@@ -28,7 +28,7 @@ SpecBegin(SKYOperation)
         __block SKYContainer *container = nil;
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
+            container = [SKYContainer testContainer];
             [container.auth updateWithUserRecordID:@"USER_ID"
                                        accessToken:[[SKYAccessToken alloc]
                                                        initWithTokenString:@"ACCESS_TOKEN"]];

--- a/Example/Tests/SKYPostAssetOperationTests.m
+++ b/Example/Tests/SKYPostAssetOperationTests.m
@@ -58,7 +58,7 @@ SpecBegin(SKYPostAssetOperation)
                        }];
             operation.container = container;
 
-            NSURLRequest *request = [operation makeURLRequest];
+            NSURLRequest *request = [operation makeURLRequestWithError:nil];
 
             expect(request.HTTPMethod).to.equal(@"POST");
             expect(request.URL.absoluteString)

--- a/Example/Tests/SKYPostAssetOperationTests.m
+++ b/Example/Tests/SKYPostAssetOperationTests.m
@@ -30,9 +30,7 @@ SpecBegin(SKYPostAssetOperation)
         __block SKYAsset *asset = nil;
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
-            [container configAddress:@"http://skygear.dev/"];
-            [container configureWithAPIKey:@"API-KEY"];
+            container = [SKYContainer testContainer];
             [container.auth updateWithUserRecordID:@"Test-User-ID"
                                        accessToken:[[SKYAccessToken alloc]
                                                        initWithTokenString:@"Test-Access-Token"]];
@@ -66,7 +64,7 @@ SpecBegin(SKYPostAssetOperation)
             expect(request.URL.absoluteString)
                 .to.equal(
                     @"http://asset.skygear.dev/dev/f8b9d47f-6188-46fa-b26f-0ac73fea2569-boy.txt");
-            expect(request.allHTTPHeaderFields[@"X-Skygear-API-Key"]).to.equal(@"API-KEY");
+            expect(request.allHTTPHeaderFields[@"X-Skygear-API-Key"]).to.equal(@"API_KEY");
             expect(request.allHTTPHeaderFields[@"X-Skygear-Access-Token"])
                 .to.equal(@"Test-Access-Token");
             expect(request.allHTTPHeaderFields[@"Content-Type"]).notTo.beNil();

--- a/Example/Tests/SKYPushContainerTests.m
+++ b/Example/Tests/SKYPushContainerTests.m
@@ -33,7 +33,7 @@ SpecBegin(SKYPushContainer)
         __block bool notificationPosted = NO;
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
+            container = [SKYContainer testContainer];
             notificationObserver = [[NSNotificationCenter defaultCenter]
                 addObserverForName:SKYContainerDidRegisterDeviceNotification
                             object:container
@@ -128,7 +128,7 @@ describe(@"unregister device", ^{
     });
 
     beforeEach(^{
-        container = [[SKYContainer alloc] init];
+        container = [SKYContainer testContainer];
         [container.auth
             updateWithUserRecordID:@"user_id_001"
                        accessToken:[[SKYAccessToken alloc] initWithTokenString:@"access_token"]];

--- a/Example/Tests/SKYQueryOperationTests.m
+++ b/Example/Tests/SKYQueryOperationTests.m
@@ -28,8 +28,7 @@ SpecBegin(SKYQueryOperation)
         __block SKYDatabase *database = nil;
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
-            [container configureWithAPIKey:@"API_KEY"];
+            container = [SKYContainer testContainer];
             [container.auth updateWithUserRecordID:@"USER_ID"
                                        accessToken:[[SKYAccessToken alloc]
                                                        initWithTokenString:@"ACCESS_TOKEN"]];

--- a/Example/Tests/SKYQueryOperationTests.m
+++ b/Example/Tests/SKYQueryOperationTests.m
@@ -43,7 +43,7 @@ SpecBegin(SKYQueryOperation)
             SKYDatabase *database = [[SKYContainer defaultContainer] publicCloudDatabase];
             operation.container = container;
             operation.database = database;
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
             SKYRequest *request = operation.request;
             expect([request class]).to.beSubclassOf([SKYRequest class]);
             expect(request.action).to.equal(@"record:query");
@@ -64,7 +64,7 @@ SpecBegin(SKYQueryOperation)
             SKYDatabase *database = [[SKYContainer defaultContainer] publicCloudDatabase];
             operation.container = container;
             operation.database = database;
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
             SKYRequest *request = operation.request;
             expect([request class]).to.beSubclassOf([SKYRequest class]);
             expect(request.action).to.equal(@"record:query");
@@ -88,7 +88,7 @@ SpecBegin(SKYQueryOperation)
             SKYDatabase *database = [[SKYContainer defaultContainer] publicCloudDatabase];
             operation.container = container;
             operation.database = database;
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
             SKYRequest *request = operation.request;
 
             expect(request.payload[@"sort"][0]).to.equal(@[
@@ -103,7 +103,7 @@ SpecBegin(SKYQueryOperation)
             SKYDatabase *database = [[SKYContainer defaultContainer] publicCloudDatabase];
             operation.container = container;
             operation.database = database;
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
             SKYRequest *request = operation.request;
 
             expect(request.payload[@"include"]).to.equal(@{

--- a/Example/Tests/SKYRecordStorageCoordinatorTests.m
+++ b/Example/Tests/SKYRecordStorageCoordinatorTests.m
@@ -30,8 +30,7 @@ SpecBegin(SKYRecordStorageCoordinator)
         __block SKYRecordStorageCoordinator *coordinator = nil;
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
-            [container configureWithAPIKey:@"API_KEY"];
+            container = [SKYContainer testContainer];
             [container.auth updateWithUserRecordID:@"USERNAME"
                                        accessToken:[[SKYAccessToken alloc]
                                                        initWithTokenString:@"ACCESS_TOKEN"]];

--- a/Example/Tests/SKYRegisterDeviceOperationTests.m
+++ b/Example/Tests/SKYRegisterDeviceOperationTests.m
@@ -28,7 +28,7 @@ SpecBegin(SKYRegisterDeviceOperation)
         __block SKYContainer *container = nil;
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
+            container = [SKYContainer testContainer];
             [container.auth updateWithUserRecordID:@"USER_ID"
                                        accessToken:[[SKYAccessToken alloc]
                                                        initWithTokenString:@"ACCESS_TOKEN"]];

--- a/Example/Tests/SKYRegisterDeviceOperationTests.m
+++ b/Example/Tests/SKYRegisterDeviceOperationTests.m
@@ -39,7 +39,7 @@ SpecBegin(SKYRegisterDeviceOperation)
                 operationWithDeviceToken:[SKYHexer dataWithHexString:@"abcdef1234567890"]
                                    topic:@"com.example.app"];
             operation.container = container;
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
 
             SKYRequest *request = operation.request;
             expect([request class]).to.beSubclassOf([SKYRequest class]);
@@ -55,7 +55,7 @@ SpecBegin(SKYRegisterDeviceOperation)
             SKYRegisterDeviceOperation *operation =
                 [SKYRegisterDeviceOperation operationWithDeviceToken:nil topic:@"com.example.app"];
             operation.container = container;
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
 
             SKYRequest *request = operation.request;
             expect([request class]).to.beSubclassOf([SKYRequest class]);
@@ -73,7 +73,7 @@ SpecBegin(SKYRegisterDeviceOperation)
                                    topic:@"com.example.app"];
             operation.deviceID = @"DEVICE_ID";
             operation.container = container;
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
 
             SKYRequest *request = operation.request;
             expect([request class]).to.beSubclassOf([SKYRequest class]);

--- a/Example/Tests/SKYRemoveRelationsOperationTests.m
+++ b/Example/Tests/SKYRemoveRelationsOperationTests.m
@@ -44,7 +44,7 @@ SpecBegin(SKYRemoveRelationsOperation)
                 [SKYRemoveRelationsOperation operationWithType:@"follow"
                                                  usersToRemove:@[ follower1, follower2 ]];
             operation.container = container;
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
             SKYRequest *request = operation.request;
             expect([request class]).to.beSubclassOf([SKYRequest class]);
             expect(request.action).to.equal(@"relation:delete");

--- a/Example/Tests/SKYRemoveRelationsOperationTests.m
+++ b/Example/Tests/SKYRemoveRelationsOperationTests.m
@@ -29,7 +29,7 @@ SpecBegin(SKYRemoveRelationsOperation)
         __block SKYContainer *container = nil;
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
+            container = [SKYContainer testContainer];
             [container.auth updateWithUserRecordID:@"USER_ID"
                                        accessToken:[[SKYAccessToken alloc]
                                                        initWithTokenString:@"ACCESS_TOKEN"]];

--- a/Example/Tests/SKYRevokeUserRoleOperation.m
+++ b/Example/Tests/SKYRevokeUserRoleOperation.m
@@ -49,7 +49,7 @@ SpecBegin(SKYRevokeUserRoleOperation)
                            roleNames:@[ developerRoleName, testerRoleName ]];
 
             [operation setContainer:container];
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
 
             SKYRequest *request = operation.request;
             expect(request.action).to.equal(@"role:revoke");

--- a/Example/Tests/SKYRevokeUserRoleOperation.m
+++ b/Example/Tests/SKYRevokeUserRoleOperation.m
@@ -37,8 +37,7 @@ SpecBegin(SKYRevokeUserRoleOperation)
         __block SKYContainer *container;
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
-            [container configureWithAPIKey:apiKey];
+            container = [SKYContainer testContainer];
             [container.auth
                 updateWithUserRecordID:currentUserID
                            accessToken:[[SKYAccessToken alloc] initWithTokenString:token]];

--- a/Example/Tests/SKYSendPushNotificationOperationTests.m
+++ b/Example/Tests/SKYSendPushNotificationOperationTests.m
@@ -41,7 +41,7 @@ SpecBegin(SKYSendPushNotificationOperation)
         };
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
+            container = [SKYContainer testContainer];
             [container.auth updateWithUserRecordID:@"USER_ID"
                                        accessToken:[[SKYAccessToken alloc]
                                                        initWithTokenString:@"ACCESS_TOKEN"]];

--- a/Example/Tests/SKYSendPushNotificationOperationTests.m
+++ b/Example/Tests/SKYSendPushNotificationOperationTests.m
@@ -52,7 +52,7 @@ SpecBegin(SKYSendPushNotificationOperation)
                 [SKYSendPushNotificationOperation operationWithNotificationInfo:notificationInfo
                                                                 deviceIDsToSend:@[ @"johndoe" ]];
             operation.container = container;
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
 
             SKYRequest *request = operation.request;
             expect([request class]).to.beSubclassOf([SKYRequest class]);
@@ -69,7 +69,7 @@ SpecBegin(SKYSendPushNotificationOperation)
                 [SKYSendPushNotificationOperation operationWithNotificationInfo:notificationInfo
                                                                   userIDsToSend:@[ @"johndoe" ]];
             operation.container = container;
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
 
             SKYRequest *request = operation.request;
             expect([request class]).to.beSubclassOf([SKYRequest class]);
@@ -86,7 +86,7 @@ SpecBegin(SKYSendPushNotificationOperation)
                 operationWithNotificationInfo:notificationInfo
                                 userIDsToSend:@[ @"johndoe", @"janedoe" ]];
             operation.container = container;
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
 
             SKYRequest *request = operation.request;
             expect([request class]).to.beSubclassOf([SKYRequest class]);
@@ -104,7 +104,7 @@ SpecBegin(SKYSendPushNotificationOperation)
                                 userIDsToSend:@[ @"johndoe" ]
                                         topic:@"io.skygear.example"];
             operation.container = container;
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
 
             SKYRequest *request = operation.request;
             expect([request class]).to.beSubclassOf([SKYRequest class]);

--- a/Example/Tests/SKYSetDisableUserOperationTests.m
+++ b/Example/Tests/SKYSetDisableUserOperationTests.m
@@ -33,8 +33,7 @@ SpecBegin(SKYSetDisableUserOperation)
         __block SKYContainer *container;
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
-            [container configureWithAPIKey:apiKey];
+            container = [SKYContainer testContainer];
             [container.auth
                 updateWithUserRecordID:currentUserID
                            accessToken:[[SKYAccessToken alloc] initWithTokenString:token]];

--- a/Example/Tests/SKYSetDisableUserOperationTests.m
+++ b/Example/Tests/SKYSetDisableUserOperationTests.m
@@ -44,7 +44,7 @@ SpecBegin(SKYSetDisableUserOperation)
                 [SKYSetDisableUserOperation enableOperationWithUserID:currentUserID];
 
             [operation setContainer:container];
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
 
             SKYRequest *request = operation.request;
             expect(request.action).to.equal(@"auth:disable:set");
@@ -63,7 +63,7 @@ SpecBegin(SKYSetDisableUserOperation)
                                                                 expiry:disableExpiry];
 
             [operation setContainer:container];
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
 
             SKYRequest *request = operation.request;
             expect(request.action).to.equal(@"auth:disable:set");
@@ -83,7 +83,7 @@ SpecBegin(SKYSetDisableUserOperation)
                                                                 expiry:nil];
 
             [operation setContainer:container];
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
 
             SKYRequest *request = operation.request;
             expect(request.action).to.equal(@"auth:disable:set");

--- a/Example/Tests/SKYSetUserDefaultRoleOperationTests.m
+++ b/Example/Tests/SKYSetUserDefaultRoleOperationTests.m
@@ -47,7 +47,7 @@ SpecBegin(SKYSetUserDefaultRoleOperation)
                 [SKYSetUserDefaultRoleOperation operationWithRoles:roles];
 
             [operation setContainer:container];
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
 
             SKYRequest *request = operation.request;
             expect(request.action).to.equal(@"role:default");

--- a/Example/Tests/SKYSetUserDefaultRoleOperationTests.m
+++ b/Example/Tests/SKYSetUserDefaultRoleOperationTests.m
@@ -36,8 +36,7 @@ SpecBegin(SKYSetUserDefaultRoleOperation)
         __block SKYContainer *container = nil;
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
-            [container configureWithAPIKey:apiKey];
+            container = [SKYContainer testContainer];
             [container.auth
                 updateWithUserRecordID:currentUserID
                            accessToken:[[SKYAccessToken alloc] initWithTokenString:token]];

--- a/Example/Tests/SKYSignupUserOperationTests.m
+++ b/Example/Tests/SKYSignupUserOperationTests.m
@@ -39,7 +39,7 @@ SpecBegin(SKYSignupUserOperation)
                                                      password:@"password"];
 
             operation.container = container;
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
             SKYRequest *request = operation.request;
             expect([request class]).to.beSubclassOf([SKYRequest class]);
             expect(request.action).to.equal(@"auth:signup");
@@ -52,7 +52,7 @@ SpecBegin(SKYSignupUserOperation)
         it(@"anonymous user request", ^{
             SKYSignupUserOperation *operation = [SKYSignupUserOperation operationWithAnonymousUser];
             operation.container = container;
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
             SKYRequest *request = operation.request;
             expect([request class]).to.beSubclassOf([SKYRequest class]);
             expect(request.action).to.equal(@"auth:signup");

--- a/Example/Tests/SKYSignupUserOperationTests.m
+++ b/Example/Tests/SKYSignupUserOperationTests.m
@@ -27,8 +27,7 @@ SpecBegin(SKYSignupUserOperation)
         __block SKYContainer *container = nil;
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
-            [container configureWithAPIKey:@"API_KEY"];
+            container = [SKYContainer testContainer];
             [container.auth updateWithUserRecordID:@"USER_ID"
                                        accessToken:[[SKYAccessToken alloc]
                                                        initWithTokenString:@"ACCESS_TOKEN"]];

--- a/Example/Tests/SKYUnregisterDeviceOperationTests.m
+++ b/Example/Tests/SKYUnregisterDeviceOperationTests.m
@@ -27,7 +27,7 @@ SpecBegin(SKYUnregisterDeviceOperation)
         __block SKYContainer *container = nil;
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
+            container = [SKYContainer testContainer];
             [container.auth updateWithUserRecordID:@"user_id"
                                        accessToken:[[SKYAccessToken alloc]
                                                        initWithTokenString:@"access_token"]];

--- a/Example/Tests/SKYUnregisterDeviceOperationTests.m
+++ b/Example/Tests/SKYUnregisterDeviceOperationTests.m
@@ -41,7 +41,7 @@ SpecBegin(SKYUnregisterDeviceOperation)
             SKYUnregisterDeviceOperation *operation =
                 [SKYUnregisterDeviceOperation operationWithDeviceID:@"device_id"];
             [operation setContainer:container];
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
 
             SKYRequest *request = operation.request;
             expect([request class]).to.beSubclassOf([SKYRequest class]);

--- a/Example/Tests/SKYUpdateUserOperationTests.m
+++ b/Example/Tests/SKYUpdateUserOperationTests.m
@@ -35,8 +35,7 @@ SpecBegin(SKYUpdateUserOperation)
 
         __block SKYContainer *container = nil;
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
-            [container configureWithAPIKey:apiKey];
+            container = [SKYContainer testContainer];
             [container.auth
                 updateWithUserRecordID:currentUserID
                            accessToken:[[SKYAccessToken alloc] initWithTokenString:token]];

--- a/Example/Tests/SKYUploadAssetOperationTests.m
+++ b/Example/Tests/SKYUploadAssetOperationTests.m
@@ -46,7 +46,7 @@ SpecBegin(SKYUploadAssetOperation)
             SKYUploadAssetOperation *operation = [SKYUploadAssetOperation operationWithAsset:asset];
             operation.container = container;
 
-            NSURLRequest *request = [operation makeURLRequest];
+            NSURLRequest *request = [operation makeURLRequestWithError:nil];
 
             expect(request.HTTPMethod).to.equal(@"PUT");
             expect(request.URL)
@@ -66,7 +66,7 @@ SpecBegin(SKYUploadAssetOperation)
             SKYUploadAssetOperation *operation = [SKYUploadAssetOperation operationWithAsset:asset];
             operation.container = container;
 
-            NSURLRequest *request = [operation makeURLRequest];
+            NSURLRequest *request = [operation makeURLRequestWithError:nil];
 
             expect(request.HTTPMethod).to.equal(@"PUT");
             expect(request.URL)

--- a/Example/Tests/SKYUploadAssetOperationTests.m
+++ b/Example/Tests/SKYUploadAssetOperationTests.m
@@ -30,9 +30,7 @@ SpecBegin(SKYUploadAssetOperation)
         __block SKYAsset *asset = nil;
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
-            [container configAddress:@"http://skygear.test/"];
-            [container configureWithAPIKey:@"API_KEY"];
+            container = [SKYContainer testContainer];
             [container.auth updateWithUserRecordID:@"USER_ID"
                                        accessToken:[[SKYAccessToken alloc]
                                                        initWithTokenString:@"ACCESS_TOKEN"]];
@@ -52,7 +50,7 @@ SpecBegin(SKYUploadAssetOperation)
 
             expect(request.HTTPMethod).to.equal(@"PUT");
             expect(request.URL)
-                .to.equal([NSURL URLWithString:@"http://skygear.test/files/boy.txt"]);
+                .to.equal([NSURL URLWithString:@"http://skygear.localhost/files/boy.txt"]);
             expect(request.allHTTPHeaderFields).to.equal(@{
                 @"X-Skygear-API-Key" : @"API_KEY",
                 @"X-Skygear-Access-Token" : @"ACCESS_TOKEN",
@@ -72,7 +70,7 @@ SpecBegin(SKYUploadAssetOperation)
 
             expect(request.HTTPMethod).to.equal(@"PUT");
             expect(request.URL)
-                .to.equal([NSURL URLWithString:@"http://skygear.test/files/boy%25boy.txt"]);
+                .to.equal([NSURL URLWithString:@"http://skygear.localhost/files/boy%25boy.txt"]);
             expect(request.allHTTPHeaderFields).to.equal(@{
                 @"X-Skygear-API-Key" : @"API_KEY",
                 @"X-Skygear-Access-Token" : @"ACCESS_TOKEN",

--- a/Example/Tests/SSO/SKYAuthContainerSSOTests.m
+++ b/Example/Tests/SSO/SKYAuthContainerSSOTests.m
@@ -42,9 +42,8 @@ SpecBegin(SKYAuthContainerSSO)
             };
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
+            container = [SKYContainer testContainer];
             container.defaultTimeoutInterval = 1.0;
-            [container configureWithAPIKey:@"API_KEY"];
             [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
                 NSString *path = [[request URL] path];
                 return [path isEqualToString:@"/sso/custom_token/login"];

--- a/Example/Tests/SSO/SKYLoginCustomTokenOperationTests.m
+++ b/Example/Tests/SSO/SKYLoginCustomTokenOperationTests.m
@@ -37,7 +37,7 @@ SpecBegin(SKYLoginCustomTokenOperation)
             SKYLoginCustomTokenOperation *operation =
                 [SKYLoginCustomTokenOperation operationWithCustomToken:@"eyXXX"];
             operation.container = container;
-            [operation prepareForRequest];
+            [operation makeURLRequestWithError:nil];
             SKYRequest *request = operation.request;
             expect([request class]).to.beSubclassOf([SKYRequest class]);
             expect(request.action).to.equal(@"sso:custom_token:login");

--- a/Example/Tests/SSO/SKYLoginCustomTokenOperationTests.m
+++ b/Example/Tests/SSO/SKYLoginCustomTokenOperationTests.m
@@ -27,8 +27,7 @@ SpecBegin(SKYLoginCustomTokenOperation)
         __block SKYContainer *container = nil;
 
         beforeEach(^{
-            container = [[SKYContainer alloc] init];
-            [container configureWithAPIKey:@"API_KEY"];
+            container = [SKYContainer testContainer];
             [container.auth updateWithUserRecordID:@"USER_ID"
                                        accessToken:[[SKYAccessToken alloc]
                                                        initWithTokenString:@"ACCESS_TOKEN"]];

--- a/Example/Tests/Tests-Prefix.pch
+++ b/Example/Tests/Tests-Prefix.pch
@@ -12,5 +12,6 @@
   #import <OCMock/OCMock.h>
   #import <OHHTTPStubs/OHHTTPStubs.h>
   #import <OHHTTPStubs/OHHTTPStubsResponse+JSON.h>
+  #import "SKYContainer+Test.h"
 
 #endif

--- a/Pod/Classes/SKYAssignUserRoleOperation.m
+++ b/Pod/Classes/SKYAssignUserRoleOperation.m
@@ -41,6 +41,16 @@
     return self;
 }
 
+- (BOOL)requiresAPIKey
+{
+    return YES;
+}
+
+- (BOOL)requiresAccessToken
+{
+    return YES;
+}
+
 // override
 - (void)prepareForRequest
 {
@@ -49,19 +59,6 @@
                                                   @"users" : self.userIDs,
                                                   @"roles" : self.roleNames,
                                               }];
-    self.request.APIKey = self.container.APIKey;
-    self.request.accessToken = self.container.auth.currentAccessToken;
-}
-
-// override
-- (void)operationWillStart
-{
-    [super operationWillStart];
-    if (!self.container.auth.currentAccessToken) {
-        @throw [NSException exceptionWithName:NSInvalidArgumentException
-                                       reason:@"SKYContainer has no currently logged-in user"
-                                     userInfo:nil];
-    }
 }
 
 // override

--- a/Pod/Classes/SKYChangePasswordOperation.m
+++ b/Pod/Classes/SKYChangePasswordOperation.m
@@ -39,6 +39,11 @@
     return [[self alloc] initWithOldPassword:oldPassword passwordToSet:newPassword];
 }
 
+- (BOOL)requiresAccessToken
+{
+    return YES;
+}
+
 - (void)prepareForRequest
 {
     NSDictionary *payload = @{
@@ -46,17 +51,6 @@
         @"password" : self.passwordToSet,
     };
     self.request = [[SKYRequest alloc] initWithAction:@"auth:password" payload:payload];
-    self.request.accessToken = self.container.auth.currentAccessToken;
-}
-
-- (void)operationWillStart
-{
-    [super operationWillStart];
-    if (!self.container.auth.currentAccessToken) {
-        @throw [NSException exceptionWithName:NSInvalidArgumentException
-                                       reason:@"SKYContainer has no currently logged-in user"
-                                     userInfo:nil];
-    }
 }
 
 - (void)handleRequestError:(NSError *)error

--- a/Pod/Classes/SKYContainer.m
+++ b/Pod/Classes/SKYContainer.m
@@ -99,26 +99,8 @@ NSString *const SKYContainerDidChangeCurrentUserNotification =
 - (void)configAddress:(NSString *)address
 {
     NSURL *url = [NSURL URLWithString:address];
-    NSString *schema = url.scheme;
-    if (![schema isEqualToString:@"http"] && ![schema isEqualToString:@"https"]) {
-        NSLog(@"Error: only http or https schema is accepted");
-        return;
-    }
-
-    NSString *host = url.host;
-    if (url.port) {
-        host = [host stringByAppendingFormat:@":%@", url.port];
-    }
-
-    NSString *webSocketSchema = [schema isEqualToString:@"https"] ? @"wss" : @"ws";
-
     _endPointAddress = url;
-
-    self.pubsub.pubsubClient.endPointAddress =
-        [[NSURL alloc] initWithScheme:webSocketSchema host:host path:@"/pubsub"];
-    self.pubsub.internalPubsubClient.endPointAddress =
-        [[NSURL alloc] initWithScheme:webSocketSchema host:host path:@"/_/pubsub"];
-    [self.pubsub configInternalPubsubClient];
+    [self.pubsub configAddress:address];
 }
 
 - (void)configureWithAPIKey:(NSString *)APIKey
@@ -134,9 +116,7 @@ NSString *const SKYContainerDidChangeCurrentUserNotification =
     [self willChangeValueForKey:@"applicationIdentifier"];
     _APIKey = [APIKey copy];
     [self didChangeValueForKey:@"applicationIdentifier"];
-
-    self.pubsub.pubsubClient.APIKey = _APIKey;
-    self.pubsub.internalPubsubClient.APIKey = _APIKey;
+    [self.pubsub configureWithAPIKey:APIKey];
 }
 
 - (void)addOperation:(SKYOperation *)operation

--- a/Pod/Classes/SKYContainer.m
+++ b/Pod/Classes/SKYContainer.m
@@ -31,8 +31,6 @@
 
 NSString *const SKYVersion = SKY_VERSION;
 
-NSString *const SKYContainerRequestBaseURL = @"http://localhost:5000/v1";
-
 NSString *const SKYContainerDidChangeCurrentUserNotification =
     @"SKYContainerDidChangeCurrentUserNotification";
 
@@ -49,7 +47,7 @@ NSString *const SKYContainerDidChangeCurrentUserNotification =
 {
     self = [super init];
     if (self) {
-        _endPointAddress = [NSURL URLWithString:SKYContainerRequestBaseURL];
+        _endPointAddress = nil;
         _APIKey = nil;
         _defaultTimeoutInterval = 60.0;
 

--- a/Pod/Classes/SKYContainer.m
+++ b/Pod/Classes/SKYContainer.m
@@ -148,6 +148,20 @@ NSString *const SKYContainerDidChangeCurrentUserNotification =
     [self.operationQueue addOperation:operation];
 }
 
+- (NSURL *)endPointAddress
+{
+    static BOOL warnedOnce;
+
+    if (!_endPointAddress && !warnedOnce) {
+        NSLog(
+            @"Warning: Container is not configured with an endpoint address. Please call -[%@ %@].",
+            NSStringFromClass([SKYContainer class]),
+            NSStringFromSelector(@selector(configAddress:)));
+        warnedOnce = YES;
+    }
+    return _endPointAddress;
+}
+
 - (NSString *)APIKey
 {
     static BOOL warnedOnce;

--- a/Pod/Classes/SKYDefineAdminRolesOperation.m
+++ b/Pod/Classes/SKYDefineAdminRolesOperation.m
@@ -36,6 +36,11 @@
     return self;
 }
 
+- (BOOL)requiresAccessToken
+{
+    return YES;
+}
+
 // override
 - (void)prepareForRequest
 {
@@ -47,18 +52,6 @@
 
     self.request =
         [[SKYRequest alloc] initWithAction:@"role:admin" payload:@{@"roles" : roleNames}];
-    self.request.accessToken = self.container.auth.currentAccessToken;
-}
-
-// override
-- (void)operationWillStart
-{
-    [super operationWillStart];
-    if (!self.container.auth.currentAccessToken) {
-        @throw [NSException exceptionWithName:NSInvalidArgumentException
-                                       reason:@"SKYContainer has no currently logged-in user"
-                                     userInfo:nil];
-    }
 }
 
 // override

--- a/Pod/Classes/SKYDefineCreationAccessOperation.m
+++ b/Pod/Classes/SKYDefineCreationAccessOperation.m
@@ -37,6 +37,11 @@
     return self;
 }
 
+- (BOOL)requiresAccessToken
+{
+    return YES;
+}
+
 // override
 - (void)prepareForRequest
 {
@@ -54,18 +59,6 @@
     self.request = [[SKYRequest alloc]
         initWithAction:@"schema:access"
                payload:@{@"type" : self.recordType, @"create_roles" : roleNames}];
-    self.request.accessToken = self.container.auth.currentAccessToken;
-}
-
-// override
-- (void)operationWillStart
-{
-    [super operationWillStart];
-    if (!self.container.auth.currentAccessToken) {
-        @throw [NSException exceptionWithName:NSInvalidArgumentException
-                                       reason:@"SKYContainer has no currently logged-in user"
-                                     userInfo:nil];
-    }
 }
 
 // override

--- a/Pod/Classes/SKYDefineDefaultAccessOperation.m
+++ b/Pod/Classes/SKYDefineDefaultAccessOperation.m
@@ -42,6 +42,16 @@
     return self;
 }
 
+- (BOOL)requiresAPIKey
+{
+    return YES;
+}
+
+- (BOOL)requiresAccessToken
+{
+    return YES;
+}
+
 // override
 - (void)prepareForRequest
 {
@@ -57,19 +67,6 @@
     self.request = [[SKYRequest alloc]
         initWithAction:@"schema:default_access"
                payload:@{@"type" : self.recordType, @"default_access" : serialized}];
-    self.request.APIKey = self.container.APIKey;
-    self.request.accessToken = self.container.auth.currentAccessToken;
-}
-
-// override
-- (void)operationWillStart
-{
-    [super operationWillStart];
-    if (!self.container.auth.currentAccessToken) {
-        @throw [NSException exceptionWithName:NSInvalidArgumentException
-                                       reason:@"SKYContainer has no currently logged-in user"
-                                     userInfo:nil];
-    }
 }
 
 // override

--- a/Pod/Classes/SKYDownloadAssetOperation.m
+++ b/Pod/Classes/SKYDownloadAssetOperation.m
@@ -51,7 +51,7 @@
     return self.downloadAssetProgressBlock != nil;
 }
 
-- (NSURLRequest *)makeURLRequest
+- (NSURLRequest *)makeURLRequestWithError:(NSError **)error
 {
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:self.asset.url];
     return request;

--- a/Pod/Classes/SKYError.h
+++ b/Pod/Classes/SKYError.h
@@ -43,6 +43,7 @@ typedef enum : NSInteger {
     SKYErrorBadResponse = 8,
     SKYErrorInvalidData = 9,
     SKYErrorRequestPayloadTooLarge = 10,
+    SKYErrorContainerNotConfigured = 11,
 
     SKYErrorNotAuthenticated = 101,
     SKYErrorPermissionDenied = 102,

--- a/Pod/Classes/SKYError.m
+++ b/Pod/Classes/SKYError.m
@@ -43,6 +43,8 @@ NSString *SKYErrorNameWithCode(SKYErrorCode errorCode)
             return @"InvalidData";
         case SKYErrorRequestPayloadTooLarge:
             return @"RequestPayloadTooLarge";
+        case SKYErrorContainerNotConfigured:
+            return @"ContainerNotConfigured";
         case SKYErrorNotAuthenticated:
             return @"NotAuthenticated";
         case SKYErrorPermissionDenied:
@@ -124,6 +126,8 @@ NSString *SKYErrorLocalizedDescriptionWithCodeAndInfo(SKYErrorCode errorCode,
         case SKYErrorRequestPayloadTooLarge:
             return NSLocalizedString(@"The data trying to be sent to the server is too large.",
                                      nil);
+        case SKYErrorContainerNotConfigured:
+            return NSLocalizedString(@"The client app container is not properly configured.", nil);
         case SKYErrorNotAuthenticated:
             return NSLocalizedString(@"You have to be authenticated to perform this operation.",
                                      nil);

--- a/Pod/Classes/SKYFetchUserRoleOperation.m
+++ b/Pod/Classes/SKYFetchUserRoleOperation.m
@@ -40,24 +40,21 @@
     return self;
 }
 
+- (BOOL)requiresAPIKey
+{
+    return YES;
+}
+
+- (BOOL)requiresAccessToken
+{
+    return YES;
+}
+
 // override
 - (void)prepareForRequest
 {
     self.request =
         [[SKYRequest alloc] initWithAction:@"role:get" payload:@{@"users" : self.userIDs}];
-    self.request.APIKey = self.container.APIKey;
-    self.request.accessToken = self.container.auth.currentAccessToken;
-}
-
-// override
-- (void)operationWillStart
-{
-    [super operationWillStart];
-    if (!self.container.auth.currentAccessToken) {
-        @throw [NSException exceptionWithName:NSInvalidArgumentException
-                                       reason:@"SKYContainer has no currently logged-in user"
-                                     userInfo:nil];
-    }
 }
 
 // override

--- a/Pod/Classes/SKYLoginUserOperation.m
+++ b/Pod/Classes/SKYLoginUserOperation.m
@@ -70,21 +70,15 @@
     }];
 }
 
+- (BOOL)requiresAPIKey
+{
+    return YES;
+}
+
 - (void)prepareForRequest
 {
     NSMutableDictionary *payload = [_authPayload mutableCopy];
     self.request = [[SKYRequest alloc] initWithAction:@"auth:login" payload:payload];
-    self.request.APIKey = self.container.APIKey;
-}
-
-- (void)operationWillStart
-{
-    [super operationWillStart];
-    if (!self.container.APIKey) {
-        @throw [NSException exceptionWithName:NSInvalidArgumentException
-                                       reason:@"SKYContainer is not configured with an API key."
-                                     userInfo:nil];
-    }
 }
 
 - (void)handleRequestError:(NSError *)error

--- a/Pod/Classes/SKYOperation.h
+++ b/Pod/Classes/SKYOperation.h
@@ -38,6 +38,16 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, readwrite) NSTimeInterval timeoutInterval;
 
+/**
+ The request requires an access token.
+ */
+@property (nonatomic, readonly) BOOL requiresAPIKey;
+
+/**
+ The request requires an access token.
+ */
+@property (nonatomic, readonly) BOOL requiresAccessToken;
+
 /// Undocumented
 - (instancetype)initWithRequest:(SKYRequest *)request;
 
@@ -108,15 +118,17 @@ NS_ASSUME_NONNULL_BEGIN
  Creates a <NSURLRequest> with <SKYRequest> specified as the property of this class.
  <SKYOperation> calls this method to create a <NSURLRequest>.
 
+ If the request cannot be created, this method should return nil and the error should be supplied.
+
  This method is expected to be overriden by subclass of <SKYOperation>. You are not expected
  to call this method directly.
  */
-- (NSURLRequest *)makeURLRequest;
+- (NSURLRequest *_Nullable)makeURLRequestWithError:(NSError **)error;
 
 /// Undocumented
-- (void)handleRequestCompletionWithData:(NSData *)data
-                               response:(NSURLResponse *)response
-                                  error:(NSError *)requestError;
+- (void)handleRequestCompletionWithData:(NSData *_Nullable)data
+                               response:(NSURLResponse *_Nullable)response
+                                  error:(NSError *_Nullable)requestError;
 
 /// Undocumented
 - (void)operationWillStart;

--- a/Pod/Classes/SKYPostAssetOperation.m
+++ b/Pod/Classes/SKYPostAssetOperation.m
@@ -137,7 +137,7 @@
 }
 
 #pragma mark - override methods
-- (NSURLRequest *)makeURLRequest
+- (NSURLRequest *)makeURLRequestWithError:(NSError **)error
 {
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:self.url];
     [request setHTTPMethod:@"POST"];

--- a/Pod/Classes/SKYPubsubContainer.h
+++ b/Pod/Classes/SKYPubsubContainer.h
@@ -40,7 +40,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, weak) id<SKYPubsubContainerDelegate> _Nullable delegate;
 
-@property (nonatomic, readonly) NSURL *_Nullable endPointAddress;
+@property (nonatomic, copy, readonly, nullable) NSURL *endPointAddress;
+
+/**
+ Gets or sets whether the internal pubsub connection is configured to connect automatically.
+ */
+@property (nonatomic, readwrite) BOOL autoInternalPubsub;
 
 /**
  Manually connect to the pubsub end-point without subscribing a channel. Normally, you can just

--- a/Pod/Classes/SKYPubsubContainer_Private.h
+++ b/Pod/Classes/SKYPubsubContainer_Private.h
@@ -34,4 +34,7 @@
 
 - (void)configInternalPubsubClient;
 
+- (void)configAddress:(NSString *)address;
+- (void)configureWithAPIKey:(NSString *)APIKey;
+
 @end

--- a/Pod/Classes/SKYRevokeUserRoleOperation.m
+++ b/Pod/Classes/SKYRevokeUserRoleOperation.m
@@ -41,6 +41,16 @@
     return self;
 }
 
+- (BOOL)requiresAPIKey
+{
+    return YES;
+}
+
+- (BOOL)requiresAccessToken
+{
+    return YES;
+}
+
 // override
 - (void)prepareForRequest
 {
@@ -49,19 +59,6 @@
                                                   @"users" : self.userIDs,
                                                   @"roles" : self.roleNames,
                                               }];
-    self.request.APIKey = self.container.APIKey;
-    self.request.accessToken = self.container.auth.currentAccessToken;
-}
-
-// override
-- (void)operationWillStart
-{
-    [super operationWillStart];
-    if (!self.container.auth.currentAccessToken) {
-        @throw [NSException exceptionWithName:NSInvalidArgumentException
-                                       reason:@"SKYContainer has no currently logged-in user"
-                                     userInfo:nil];
-    }
 }
 
 // override

--- a/Pod/Classes/SKYSetDisableUserOperation.m
+++ b/Pod/Classes/SKYSetDisableUserOperation.m
@@ -50,6 +50,16 @@
     return self;
 }
 
+- (BOOL)requiresAPIKey
+{
+    return YES;
+}
+
+- (BOOL)requiresAccessToken
+{
+    return YES;
+}
+
 // override
 - (void)prepareForRequest
 {
@@ -63,19 +73,6 @@
     }
 
     self.request = [[SKYRequest alloc] initWithAction:@"auth:disable:set" payload:payload];
-    self.request.APIKey = self.container.APIKey;
-    self.request.accessToken = self.container.auth.currentAccessToken;
-}
-
-// override
-- (void)operationWillStart
-{
-    [super operationWillStart];
-    if (!self.container.auth.currentAccessToken) {
-        @throw [NSException exceptionWithName:NSInvalidArgumentException
-                                       reason:@"SKYContainer has no currently logged-in user"
-                                     userInfo:nil];
-    }
 }
 
 // override

--- a/Pod/Classes/SKYSetUserDefaultRoleOperation.m
+++ b/Pod/Classes/SKYSetUserDefaultRoleOperation.m
@@ -36,6 +36,11 @@
     return self;
 }
 
+- (BOOL)requiresAccessToken
+{
+    return YES;
+}
+
 // override
 - (void)prepareForRequest
 {
@@ -47,18 +52,6 @@
 
     self.request =
         [[SKYRequest alloc] initWithAction:@"role:default" payload:@{@"roles" : roleNames}];
-    self.request.accessToken = self.container.auth.currentAccessToken;
-}
-
-// override
-- (void)operationWillStart
-{
-    [super operationWillStart];
-    if (!self.container.auth.currentAccessToken) {
-        @throw [NSException exceptionWithName:NSInvalidArgumentException
-                                       reason:@"SKYContainer has no currently logged-in user"
-                                     userInfo:nil];
-    }
 }
 
 // override

--- a/Pod/Classes/SKYSignupUserOperation.m
+++ b/Pod/Classes/SKYSignupUserOperation.m
@@ -66,6 +66,11 @@
     return self;
 }
 
+- (BOOL)requiresAPIKey
+{
+    return YES;
+}
+
 - (void)prepareForRequest
 {
     NSMutableDictionary *payload = [[NSMutableDictionary alloc] init];
@@ -100,17 +105,6 @@
     }
 
     self.request = [[SKYRequest alloc] initWithAction:@"auth:signup" payload:payload];
-    self.request.APIKey = self.container.APIKey;
-}
-
-- (void)operationWillStart
-{
-    [super operationWillStart];
-    if (!self.container.APIKey) {
-        @throw [NSException exceptionWithName:NSInvalidArgumentException
-                                       reason:@"SKYContainer is not configured with an API key."
-                                     userInfo:nil];
-    }
 }
 
 - (void)handleRequestError:(NSError *)error

--- a/Pod/Classes/SKYUploadAssetOperation.m
+++ b/Pod/Classes/SKYUploadAssetOperation.m
@@ -99,7 +99,7 @@
     }
 }
 
-- (NSURLRequest *)makeURLRequest
+- (NSURLRequest *)makeURLRequestWithError:(NSError **)error
 {
     NSURL *baseURL = [NSURL URLWithString:@"files/" relativeToURL:self.container.endPointAddress];
     NSURL *url =

--- a/Pod/Extensions/SSO/SKYLoginCustomTokenOperation.m
+++ b/Pod/Extensions/SSO/SKYLoginCustomTokenOperation.m
@@ -49,21 +49,15 @@
     return [[SKYLoginCustomTokenOperation alloc] initWithCustomToken:customToken];
 }
 
+- (BOOL)requiresAPIKey
+{
+    return YES;
+}
+
 - (void)prepareForRequest
 {
     NSDictionary *payload = @{@"token" : _customToken};
     self.request = [[SKYRequest alloc] initWithAction:@"sso:custom_token:login" payload:payload];
-    self.request.APIKey = self.container.APIKey;
-}
-
-- (void)operationWillStart
-{
-    [super operationWillStart];
-    if (!self.container.APIKey) {
-        @throw [NSException exceptionWithName:NSInvalidArgumentException
-                                       reason:@"SKYContainer is not configured with an API key."
-                                     userInfo:nil];
-    }
 }
 
 - (void)handleRequestError:(NSError *)error


### PR DESCRIPTION
This also removes the default API endpoint in SKYContainer. Since removing the
default API endpoint requires the test cases to configure the API endpoint,
a new feature is added to disable auto pubsub when configuring API endpoint
and API key.

connects SkygearIO/skygear-SDK-JS#395