### PR TITLE
Make explicit strong references in block

### DIFF
--- a/Pod/Classes/SKYModifyRecordsOperation.m
+++ b/Pod/Classes/SKYModifyRecordsOperation.m
@@ -52,7 +52,7 @@
     recordsByRecordID = [NSMutableDictionary dictionary];
     [self.recordsToSave enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
         [dictionariesToSave addObject:[serializer dictionaryWithRecord:obj]];
-        [recordsByRecordID setObject:obj forKey:[(SKYRecord *)obj recordID]];
+        [self->recordsByRecordID setObject:obj forKey:[(SKYRecord *)obj recordID]];
     }];
 
     NSMutableDictionary *payload = [@{

--- a/Pod/Extensions/Record Storage/SKYRecordStorage.m
+++ b/Pod/Extensions/Record Storage/SKYRecordStorage.m
@@ -219,7 +219,7 @@ NSString *const SKYRecordStorageDeletedRecordIDsKey = @"deletedRecordIDs";
 {
     [records enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
         [self deleteRecord:(SKYRecord *)obj
-                 whenConflict:_defaultResolveMethod
+                 whenConflict:self->_defaultResolveMethod
             completionHandler:nil];
     }];
 }
@@ -437,16 +437,16 @@ NSString *const SKYRecordStorageDeletedRecordIDsKey = @"deletedRecordIDs";
     }];
 
     [records enumerateObjectsUsingBlock:^(SKYRecord *obj, NSUInteger idx, BOOL *stop) {
-        [_backingStore saveRecord:obj];
-        [_savedRecordIDs addObject:obj.recordID];
-        [_records setObject:obj forKey:obj.recordID];
+        [self->_backingStore saveRecord:obj];
+        [self->_savedRecordIDs addObject:obj.recordID];
+        [self->_records setObject:obj forKey:obj.recordID];
         [oldRecordIDs removeObject:obj.recordID];
     }];
 
     [oldRecordIDs enumerateObjectsUsingBlock:^(SKYRecordID *obj, NSUInteger idx, BOOL *stop) {
-        [_backingStore deleteRecordWithRecordID:obj];
-        [_deletedRecordIDs addObject:obj];
-        [_records removeObjectForKey:obj];
+        [self->_backingStore deleteRecordWithRecordID:obj];
+        [self->_deletedRecordIDs addObject:obj];
+        [self->_records removeObjectForKey:obj];
     }];
 }
 

--- a/Pod/Extensions/Record Storage/SKYRecordSynchronizer.m
+++ b/Pod/Extensions/Record Storage/SKYRecordSynchronizer.m
@@ -164,16 +164,16 @@
                 if (storage.updating) {
                     [storage finishUpdating];
                 }
-                [_changesUpdating removeObjectForKey:change.recordID];
+                [self->_changesUpdating removeObjectForKey:change.recordID];
                 updateCount--;
                 if (updateCount <= 0) {
-                    _updating = NO;
+                    self->_updating = NO;
                     if (completionHandler) {
                         completionHandler(YES, nil);
                     }
                 }
             };
-            [_changesUpdating setObject:change forKey:change.recordID];
+            [self->_changesUpdating setObject:change forKey:change.recordID];
             updateCount++;
             [self.database executeOperation:op];
         } else if (change.action == SKYRecordChangeDelete) {
@@ -190,16 +190,16 @@
                     if (storage.updating) {
                         [storage finishUpdating];
                     }
-                    [_changesUpdating removeObjectForKey:change.recordID];
+                    [self->_changesUpdating removeObjectForKey:change.recordID];
                     updateCount--;
                     if (updateCount <= 0) {
-                        _updating = NO;
+                        self->_updating = NO;
                         if (completionHandler) {
                             completionHandler(YES, nil);
                         }
                     }
                 };
-            [_changesUpdating setObject:change forKey:change.recordID];
+            [self->_changesUpdating setObject:change forKey:change.recordID];
             updateCount++;
             [self.database executeOperation:op];
         }
@@ -209,7 +209,7 @@
 
 - (BOOL)isProcessingChange:(SKYRecordChange *)change storage:(SKYRecordStorage *)storage
 {
-    return (BOOL)[_changesUpdating objectForKey:change.recordID];
+    return (BOOL)[self->_changesUpdating objectForKey:change.recordID];
 }
 
 @end


### PR DESCRIPTION
This removes the compiler warnings complaining the use of strong self
in blocks.