### PR TITLE
Fix websocket unable to reconnect to skygear-server hosted with docker

### DIFF
--- a/Pod/Classes/SKYPubsubClient.m
+++ b/Pod/Classes/SKYPubsubClient.m
@@ -245,6 +245,7 @@ double const SKYPubsubReconnectWait = 1.0;
             wasClean:(BOOL)wasClean
 {
     _webSocket = nil;
+    _connecting = false;
     _opened = false;
 
     if (self.onCloseCallback) {


### PR DESCRIPTION
When connecting to skygear-server in docker and kill the docker container, the socket closed function get called multiple time, however the first attempt of reconnecting would never success, while it blocks the subsequent attempts.

Clearing the state would make the websocket return to the reconnect flow, and when server restarted, the websocket would reconnect normally. However, socket did close would still be called multiple times.

connect oursky/skygear-support#104